### PR TITLE
Allowing to use tied hashes for json objects.

### DIFF
--- a/lib/JSON/PP.pm
+++ b/lib/JSON/PP.pm
@@ -624,11 +624,18 @@ BEGIN {
     my $cb_sk_object;
 
     my $F_HOOK;
+    my $OBJECT_CONSTRUCTOR;
 
     my $allow_bigint;   # using Math::BigInt
     my $singlequote;    # loosely quoting
     my $loose;          # 
     my $allow_barekey;  # bareKey
+
+
+    sub object_constructor {
+        $OBJECT_CONSTRUCTOR = $_[1];
+        $_[0];
+    }
 
     # $opt flag
     # 0x00000001 .... decode_prefix
@@ -939,7 +946,7 @@ BEGIN {
 
 
     sub object {
-        my $o = {};
+        my $o = $OBJECT_CONSTRUCTOR ? &$OBJECT_CONSTRUCTOR() : {};
         my $k;
 
         decode_error('json text or perl structure exceeds maximum nesting level (max_depth set too low?)')

--- a/t/116_ordered.t
+++ b/t/116_ordered.t
@@ -1,0 +1,22 @@
+use strict;
+use Test::More;
+
+use JSON::PP;
+
+# from https://rt.cpan.org/Ticket/Display.html?id=25162
+
+SKIP: {
+    eval { require Tie::StoredOrderHash };
+    skip "Can't load Tie::StoredOrderHash.", 2 if ($@);
+
+    my $json = JSON::PP->new->object_constructor(sub { Tie::StoredOrderHash->new });
+
+    my $js = $json->decode('{"id":"int","1":"a","2":"b","3":"c","4":"d","5":"e"}');
+    my @keys = keys %$js;
+    is join(' ', @keys), 'id 1 2 3 4 5', 'Ordered';
+
+}
+
+
+done_testing();
+


### PR DESCRIPTION
Hello.

According to documentation for JSON module in future JSON::PP should have functionality to preserve order of json object keys during parsing. This patch implements it.

-- 
Regards,
Bacek