### PR TITLE
Remove 'use base' and set @ISA ourself

### DIFF
--- a/lib/JSON/PP.pm
+++ b/lib/JSON/PP.pm
@@ -4,7 +4,10 @@ package JSON::PP;
 
 use 5.005;
 use strict;
-use base qw(Exporter);
+
+use Exporter ();
+BEGIN { @JSON::PP::ISA = ('Exporter') }
+
 use overload ();
 
 use Carp ();


### PR DESCRIPTION
`base.pm` is used to import `Exporter` functionnality in JSON::PP.
But `base.pm` is an heavy module for what it does.

In recent perl (5.8.3+), we can do `use Exporter 5.57 'import'`. Unfortunately, we still support older perls. So subclassing is the only supported way.

[`parent.pm`](https://metacpan.org/module/parent) has been created to replace `base.pm`, but it is available in core only since 5.10.

So for compatibility with older perls, this patch subclass `Exporter` by setting `@ISA` directly.
