### PR TITLE
Modify Makefile.PL to set UNINST=1 if needed on old perls

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -9,6 +9,12 @@ my %prereq = $] < 5.006 ? ( 'JSON::PP::Compat5005' => 0 )
            : ()
            ;
 
+# ensure old versions installed from bundled copy in ExtUtils::MakeMaker
+# are removed when installing this; this will warn on old EU::MM but
+# still works
+my $needs_uninst = $] < 5.012
+    && ! ( $ENV{PERL_MM_OPT} && $ENV{PERL_MM_OPT} =~ /(?:INSTALL_BASE|PREFIX)/ )
+    && ! grep { /INSTALL_BASE/ || /PREFIX/ } @ARGV;
 
 WriteMakefile(
     'NAME'          => 'JSON::PP',
@@ -30,6 +36,7 @@ WriteMakefile(
             },
         } ) : ()
     ),
+    ( $needs_uninst ? ( UNINST => 1 ) : () ),
 );
 
 

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -13,6 +13,7 @@ my %prereq = $] < 5.006 ? ( 'JSON::PP::Compat5005' => 0 )
 # are removed when installing this; this will warn on old EU::MM but
 # still works
 my $needs_uninst = $] < 5.012
+    && ! $ENV{PERL_NO_HIGHLANDER}
     && ! ( $ENV{PERL_MM_OPT} && $ENV{PERL_MM_OPT} =~ /(?:INSTALL_BASE|PREFIX)/ )
     && ! grep { /INSTALL_BASE/ || /PREFIX/ } @ARGV;
 


### PR DESCRIPTION
Because ExtUtils::MakeMaker bundles JSON-PP and might install it into the core library path on Perls before 5.12, upgrades to JSON::PP will not be seen UNINST=1 to remove to old JSON::PP.  This commit adds conditional code to Makefile.PL to do that.  Similar patches are being applied to other modules bundled by EU::MM.