### PR TITLE
Fixes for incr_parse for list context and partial values

### DIFF
--- a/lib/JSON/PP.pm
+++ b/lib/JSON/PP.pm
@@ -685,10 +685,11 @@ BEGIN {
 
         my $valid_start = defined $ch; # Is there a first character for JSON structure?
 
-        my $result = value();
+        my $result = eval { value() };
 
-        return undef if ( !$result && ( $opt & 0x10000000 ) ); # for incr_parse
+        return (undef, undef, $@) if ( !$result && ( $opt & 0x10000000 ) ); # for incr_parse
 
+        decode_error($@) if $@;
         decode_error("malformed JSON string, neither array, object, number, string or atom") unless $valid_start;
 
         if ( !$idx->[ P_ALLOW_NONREF ] and !ref $result ) {
@@ -1340,7 +1341,7 @@ BEGIN {
         *JSON::PP::reftype = \&Scalar::Util::reftype;
         *JSON::PP::refaddr = \&Scalar::Util::refaddr;
     }
-    else{ # This code is from Sclar::Util.
+    else{ # This code is from Scalar::Util.
         # warn $@;
         eval 'sub UNIVERSAL::a_sub_not_likely_to_be_here { ref($_[0]) }';
         *JSON::PP::blessed = sub {
@@ -1465,15 +1466,14 @@ sub incr_parse {
             my @ret;
 
             $self->{incr_parsing} = 1;
-
             do {
-                push @ret, $self->_incr_parse( $coder, $self->{incr_text} );
+                my $obj = $self->_incr_parse( $coder, $self->{incr_text} );
+                push @ret, $obj if $obj;
 
                 unless ( !$self->{incr_nest} and $self->{incr_mode} == INCR_M_JSON ) {
                     $self->{incr_mode} = INCR_M_WS if $self->{incr_mode} != INCR_M_STR;
                 }
-
-            } until ( length $self->{incr_text} >= $self->{incr_p} );
+            } until ( !length($self->{incr_text}) || $self->{incr_p} );
 
             $self->{incr_parsing} = 0;
 
@@ -1559,10 +1559,16 @@ sub _incr_parse {
     $self->{incr_p} = $restore;
     $self->{incr_c} = $p;
 
-    my ( $obj, $tail ) = $coder->PP_decode_json( substr( $self->{incr_text}, 0, $p ), 0x10000001 );
+    my ( $obj, $tail, $err ) = $coder->PP_decode_json( substr( $self->{incr_text}, 0, $p ), 0x10000001 );
+ 
+    if ($err && $self->{incr_nest} < 0) {
+        die $err;
+    }
 
-    $self->{incr_text} = substr( $self->{incr_text}, $p );
-    $self->{incr_p} = 0;
+    if (defined $obj) {
+        $self->{incr_text} = substr( $self->{incr_text}, $p );
+        $self->{incr_p} = 0;
+    }
 
     return $obj || '';
 }


### PR DESCRIPTION
There are a couple incompatibilities with JSON:PP incremental parsing and the documented functionality, this attempts to correct those.

Particularly doing incremental parsing of a partial JSON object/string in scalar or list context should result in undef or an empty array being returned rather than croaking.  This should fix that.

Also incr_parse in list context was only returning the first JSON object, even if multiple were available, this should correct that as well.

I also added some additional unit tests to check for these cases.