### PR TITLE
always process as utf8 encoded octets when decoding

### DIFF
--- a/lib/JSON/PP.pm
+++ b/lib/JSON/PP.pm
@@ -655,6 +655,7 @@ BEGIN {
         }
         else {
             utf8::upgrade( $text );
+            utf8::encode( $text );
         }
 
         $len = length $text;
@@ -806,17 +807,12 @@ BEGIN {
                 else{
 
                     if ( ord $ch  > 127 ) {
-                        if ( $utf8 ) {
-                            unless( $ch = is_valid_utf8($ch) ) {
-                                $at -= 1;
-                                decode_error("malformed UTF-8 character in JSON string");
-                            }
-                            else {
-                                $at += $utf8_len - 1;
-                            }
+                        unless( $ch = is_valid_utf8($ch) ) {
+                            $at -= 1;
+                            decode_error("malformed UTF-8 character in JSON string");
                         }
                         else {
-                            utf8::encode( $ch );
+                            $at += $utf8_len - 1;
                         }
 
                         $is_utf8 = 1;

--- a/t/zero-mojibake.t
+++ b/t/zero-mojibake.t
@@ -1,0 +1,23 @@
+#!/usr/bin/perl
+
+use strict;
+use Test::More;
+BEGIN { plan tests => 1 };
+
+BEGIN { $ENV{PERL_JSON_BACKEND} = 0; }
+
+use JSON::PP;
+
+my $json = JSON::PP->new;
+
+my $input = q[
+{
+   "dynamic_config" : 0,
+   "x_contributors" : [
+      "å¤§æ²¢ åå®",
+      "Ãvar ArnfjÃ¶rÃ°"
+   ]
+}
+];
+eval { $json->decode($input) };
+is $@, '', 'decodes 0 with mojibake without error';


### PR DESCRIPTION
This works around a bug in perl 5.8.6 and below where substr will
sometimes return strings longer than requested for strings with the utf8
flag turned on.

This also has the advantage of speeding up the decoding operation, as
utf8 string operations are slower, usually by about 10%.  If the UTF-8
cache is disabled, as it is for perls compiled with -DDEBUGGING, the
difference is significantly larger. [rt#93450](https://rt.cpan.org/Ticket/Display.html?id=93450)
