### PR TITLE
Also escape \x{7f}, test ctl char escaping

### DIFF
--- a/lib/JSON/PP.pm
+++ b/lib/JSON/PP.pm
@@ -467,7 +467,7 @@ sub allow_bigint {
 
         $arg =~ s/([\x22\x5c\n\r\t\f\b])/$esc{$1}/g;
         $arg =~ s/\//\\\//g if ($escape_slash);
-        $arg =~ s/([\x00-\x08\x0b\x0e-\x1f])/'\\u00' . unpack('H2', $1)/eg;
+        $arg =~ s/([\x00-\x08\x0b\x0e-\x1f\x7f])/'\\u00' . unpack('H2', $1)/eg;
 
         if ($ascii) {
             $arg = JSON_PP_encode_ascii($arg);

--- a/t/118_ctl.t
+++ b/t/118_ctl.t
@@ -1,0 +1,25 @@
+use strict;
+use Test::More;
+
+BEGIN { plan tests => 7 };
+
+BEGIN { $ENV{PERL_JSON_BACKEND} = 0; }
+
+use JSON::PP;
+
+BEGIN {
+    use lib qw(t);
+    use _unicode_handling;
+}
+
+no utf8;
+
+my $json = JSON::PP->new->allow_nonref;
+
+is($json->encode("\x00"), q|"\\u0000"|); # 00-08
+is($json->encode("\x01"), q|"\\u0001"|); # 00-08
+is($json->encode("\x07"), q|"\\u0007"|); # 00-08
+is($json->encode("\x0e"), q|"\\u000e"|); # 0e-1f
+is($json->encode("\x0f"), q|"\\u000f"|); # 0e-1f
+is($json->encode("\x1f"), q|"\\u001f"|); # 0e-1f
+is($json->encode("\x7f"), q|"\\u007f"|); # 7f


### PR DESCRIPTION
So here's me story.  I attempted to print out **four** characters that I got from packing an int:

    use JSON::PP;
    my $bytes = pack "l", 2147483647;  # length $bytes is 4
    say JSON::PP->new->ascii->encode([$bytes])

And it printed out on screen what looks like **three** characters:

    ["\u00ff\u00ff\u00ff"]

There was much, much scratching of heads.  Why are there only three characters?  Because the last byte is `\x{7f}` and JSON::PP was printing it directly to the terminal as a zero-width invisible character.  This isn't consistent with the way JSON::PP turns other control chars into `\uXXXX` sequences.

This patch adds `\x{7f}` as something that should be escaped, and adds tests for those escapes