### PR TITLE
abuse bitwise ops to check for num vs string to avoid B.pm

### DIFF
--- a/lib/JSON/PP.pm
+++ b/lib/JSON/PP.pm
@@ -131,7 +131,6 @@ sub new {
         max_size    => 0,
         indent      => 0,
         FLAGS       => 0,
-        fallback      => sub { encode_error('Invalid value. JSON can only reference.') },
         indent_length => 3,
     };
 
@@ -416,7 +415,7 @@ sub allow_bigint {
         elsif( blessed($value) and  $value->isa('JSON::PP::Boolean') ){
             return $$value == 1 ? 'true' : 'false';
         }
-        elsif ($type) {
+        else {
             if ((overload::StrVal($value) =~ /=(\w+)/)[0]) {
                 return $self->value_to_json("$value");
             }
@@ -441,12 +440,6 @@ sub allow_bigint {
              }
 
         }
-        else {
-            return $self->{fallback}->($value)
-                 if ($self->{fallback} and ref($self->{fallback}) eq 'CODE');
-            return 'null';
-        }
-
     }
 
 

--- a/lib/JSON/PP.pm
+++ b/lib/JSON/PP.pm
@@ -8,7 +8,6 @@ use base qw(Exporter);
 use overload ();
 
 use Carp ();
-use B ();
 #use Devel::Peek;
 
 $JSON::PP::VERSION = '2.27300';
@@ -401,15 +400,18 @@ sub allow_bigint {
 
         return 'null' if(!defined $value);
 
-        my $b_obj = B::svref_2object(\$value);  # for round trip problem
-        my $flags = $b_obj->FLAGS;
-
-        return $value # as is 
-            if $flags & ( B::SVp_IOK | B::SVp_NOK ) and !( $flags & B::SVp_POK ); # SvTYPE is IV or NV?
-
         my $type = ref($value);
 
-        if(!$type){
+        if (!$type) {
+            no warnings 'numeric';
+            # detect numbers
+            # string & "" -> ""
+            # number & "" -> 0 (with warning)
+            # nan and inf can detect as numbers, so check with * 0
+            return $value
+                if length((my $dummy = "") & $value)
+                && 0 + $value eq $value
+                && $value * 0 == 0;
             return string_to_json($self, $value);
         }
         elsif( blessed($value) and  $value->isa('JSON::PP::Boolean') ){
@@ -1336,6 +1338,7 @@ BEGIN {
             local($@, $SIG{__DIE__}, $SIG{__WARN__});
             ref($_[0]) ? eval { $_[0]->a_sub_not_likely_to_be_here } : undef;
         };
+        require B;
         my %tmap = qw(
             B::NULL   SCALAR
             B::HV     HASH


### PR DESCRIPTION
B.pm is a rather large module to load, and numbers and strings can be
detected by abusing the behavior of bitwise operators.  Using a bitwise
operator is faster as well.

A string & "" results in ""
A number & "" results in 0 (with a warning)

Some variables won't be fully caught by this check alone.  A string like
"0.0" that has been used in a numeric context will pass the check as if
it was a number.  We detect this by making sure the string is the same
as stringifing the numeric form.

"nan" and "inf" that have been used as numbers will also pass that
check, so we detect them by making sure multiplying by 0 gives 0.