### PR TITLE
introduce wrap_string and wrap_number

### DIFF
--- a/lib/JSON/PP.pm
+++ b/lib/JSON/PP.pm
@@ -721,15 +721,20 @@ BEGIN {
 
     sub value {
         white();
-        return          if(!defined $ch);
-        return object() if($ch eq '{');
-        return array()  if($ch eq '[');
-        return string() if($ch eq '"' or ($singlequote and $ch eq "'"));
-        return number() if($ch =~ /[0-9]/ or $ch eq '-');
+        return           if(!defined $ch);
+        return object()  if($ch eq '{');
+        return array()   if($ch eq '[');
+        return string(1) if($ch eq '"' or ($singlequote and $ch eq "'"));
+        return number()  if($ch =~ /[0-9]/ or $ch eq '-');
         return word();
     }
 
+    sub quotedKey {
+        string(0);
+    }
+
     sub string {
+        my ($wrap) = @_;
         my ($i, $s, $t, $u);
         my $utf16;
         my $is_utf8;
@@ -752,7 +757,7 @@ BEGIN {
 
                     utf8::decode($s) if($is_utf8);
 
-                    return $s;
+                    return $wrap ? wrap_string($s) : $s;
                 }
                 elsif($ch eq '\\'){
                     next_chr();
@@ -831,6 +836,10 @@ BEGIN {
         }
 
         decode_error("unexpected end of string while parsing JSON string");
+    }
+
+    sub wrap_string {
+      return $_[0];
     }
 
 
@@ -953,7 +962,10 @@ BEGIN {
         }
         else {
             while (defined $ch) {
-                $k = ($allow_barekey and $ch ne '"' and $ch ne "'") ? bareKey() : string();
+                $k = ($allow_barekey and $ch ne '"' and $ch ne "'")
+                   ? bareKey()
+                   : quotedKey();
+
                 white();
 
                 if(!defined $ch or $ch ne ':'){
@@ -1128,6 +1140,11 @@ BEGIN {
 
         $v .= $n;
 
+        wrap_number($v);
+    }
+
+    sub wrap_number {
+        my ($v) = @_;
         if ($v !~ /[.eE]/ and length $v > $max_intsize) {
             if ($allow_bigint) { # from Adam Sussman
                 require Math::BigInt;
@@ -1144,7 +1161,6 @@ BEGIN {
 
         return 0+$v;
     }
-
 
     sub is_valid_utf8 {
 


### PR DESCRIPTION
I'm not suggesting this PR be taken as is, although I think it's *okay*.

I need to test third party APIs and ensure that they are issuing JSON conforming to specifications.  This means knowing whether they return `3` or `"3"`.  To do this, I added a wrap_string and wrap_number routine that do nothing new.  I can then wrap them in other code, like this:

```perl
use strict;
use warnings;
use Data::Dumper;
use JSON::PP;

$Data::Dumper::Sortkeys = 1;

my $JSON = JSON::PP->new;

package JSON::string {
  use overload '""' => sub { ${ $_[0] } }, fallback => 1;
  sub new { my $x = $_[1]; bless \$x, $_[0]; }
  sub value { ${ $_[0] } }
}

package JSON::number {
  use overload '0+' => sub { ${ $_[0] } }, fallback => 1;
  sub new { my $x = $_[1]; bless \$x, $_[0]; }
  sub value { ${ $_[0] } }
}

{
  my $str = \&JSON::PP::wrap_string;
  my $num = \&JSON::PP::wrap_number;

  local *JSON::PP::wrap_string;
  local *JSON::PP::wrap_number;

  {
    no warnings 'redefine';
    *JSON::PP::wrap_string = sub {
      my ($s) = @_;
      JSON::string->new($str->($s));
    };

    no warnings 'redefine';
    *JSON::PP::wrap_number = sub {
      my ($n, $b) = @_;
      $n = $num->($n, $b);
      JSON::number->new($num->($n, $b));
    };
  }

  my $json = q<{"num":123, "str":"this is a string"}>;
  warn Dumper({
    input  => $json,
    output => $JSON->decode($json)
  });
}

my $json = q<{"num":123, "str":"this is a string"}>;
warn Dumper({
  input  => $json,
  output => $JSON->decode($json)
});
```

Do you think this is something we can move forward with?