### PR TITLE
Correctly convert objects when TO_JSON returns false

### DIFF
--- a/lib/JSON/PP.pm
+++ b/lib/JSON/PP.pm
@@ -367,7 +367,7 @@ sub allow_bigint {
             if ( OLD_PERL ) { utf8::decode($k) } # key for Perl 5.6 / be optimized
             push @res, string_to_json( $self, $k )
                           .  $del
-                          . ( $self->object_to_json( $obj->{$k} ) || $self->value_to_json( $obj->{$k} ) );
+                          . ( ref $obj->{$k} ? $self->object_to_json( $obj->{$k} ) : $self->value_to_json( $obj->{$k} ) );
         }
 
         --$depth;
@@ -387,7 +387,7 @@ sub allow_bigint {
         my ($pre, $post) = $indent ? $self->_up_indent() : ('', '');
 
         for my $v (@$obj){
-            push @res, $self->object_to_json($v) || $self->value_to_json($v);
+            push @res, ref($v) ? $self->object_to_json($v) : $self->value_to_json($v);
         }
 
         --$depth;


### PR DESCRIPTION
If TO_JSON returns a value that evaluates as false, JSON::PP was
reconverting the object as a value:

    $self->object_to_json($v) || $self->value_to_json($v)

This commit changes the two expressions of that type to dispatch
with a ternary instead:

    ref $v ? $self->object_to_json($v) : $self->value_to_json($v)

As far as I can tell, there were no cases where "object_to_json" was
returning false as a failure condition.  If the undocumented 'fallback'
parameter were changed to do so, then it could happen, but I think
such behavior is a bug.

