### PR TITLE
CVE-2016-1238: avoid loading optional modules from default .

### DIFF
--- a/bin/json_pp
+++ b/bin/json_pp
@@ -1,5 +1,6 @@
 #!/usr/bin/perl
 
+BEGIN { pop @INC if $INC[-1] eq '.' }
 use strict;
 use Getopt::Long;
 

--- a/lib/JSON/PP.pm
+++ b/lib/JSON/PP.pm
@@ -1271,6 +1271,8 @@ sub _decode_unicode {
 BEGIN {
 
     unless ( defined &utf8::is_utf8 ) {
+       local @INC = @INC;
+       pop @INC if $INC[-1] eq '.';
        require Encode;
        *utf8::is_utf8 = *Encode::is_utf8;
     }
@@ -1332,6 +1334,8 @@ BEGIN {
 #
 
 BEGIN {
+    local @INC = @INC;
+    pop @INC if $INC[-1] eq '.';
     eval 'require Scalar::Util';
     unless($@){
         *JSON::PP::blessed = \&Scalar::Util::blessed;


### PR DESCRIPTION
JSON::PP treats Scalar::Util as optional and may load Encode, which
treats Encode::ConfigLocal as optional.

With the default . in @INC, and if Encode::ConfigLocal is not in
the default locations, an attacker can create for example
/tmp/Encode/ConfigLocal.pm, and if a process using JSON::PP is started
from /tmp, perl will run the attacker's code.

The change to json_pp is purely precautionary.

The changes to JSON:PP were not included in the recent security patches
since Scalar::Util is always available, and Encode was patched to
prevent the problem there.