### PR TITLE
fixes potential for arbitrary code injection

### DIFF
--- a/bin/json_pp
+++ b/bin/json_pp
@@ -2,6 +2,7 @@
 
 use strict;
 use Getopt::Long;
+no lib '.';
 
 use JSON::PP ();
 


### PR DESCRIPTION
The problem is that the current working directory really should be treated as insecure since people dont think about where they run programs like this.  This approach prevents any dependencies from loading solely because you happen to be in the same directory as them.