### PR TITLE
Add a method JSON::PP::number_if_looks_like_one. Given a scalar $a, t…

### DIFF
--- a/lib/JSON/PP.pm
+++ b/lib/JSON/PP.pm
@@ -318,7 +318,7 @@ sub allow_bigint {
         elsif ($type) { # blessed object?
             if (blessed($obj)) {
 
-                return $self->value_to_json($obj) if ( $obj->isa('JSON::PP::Boolean') );
+                return $self->value_to_json($obj) if ( $obj->isa('JSON::PP::Boolean') || $obj->isa('JSON::PP::NumberIfLooksLikeOne') );
 
                 if ( $convert_blessed and $obj->can('TO_JSON') ) {
                     my $result = $obj->TO_JSON();
@@ -415,6 +415,10 @@ sub allow_bigint {
         }
         elsif( blessed($value) and  $value->isa('JSON::PP::Boolean') ){
             return $$value == 1 ? 'true' : 'false';
+        }
+        elsif( blessed($value) and $value->isa('JSON::PP::NumberIfLooksLikeOne') ){
+            return $$value if Scalar::Util::looks_like_number($$value);
+            return $self->object_to_json($$value);
         }
         elsif ($type) {
             if ((overload::StrVal($value) =~ /=(\w+)/)[0]) {
@@ -1402,6 +1406,10 @@ sub is_bool { defined $_[0] and UNIVERSAL::isa($_[0], "JSON::PP::Boolean"); }
 sub true  { $JSON::PP::true  }
 sub false { $JSON::PP::false }
 sub null  { undef; }
+
+sub number_if_looks_like_one {
+    bless \(my $dummy = $_[0]), 'JSON::PP::NumberIfLooksLikeOne';
+}
 
 ###############################
 


### PR DESCRIPTION
…he return value of JSON::PP::number_if_looks_like_one($a) will be encoded as a number if looks_like_number($a) returns true.

With this, it becomes possible to encode decimal numbers with trailing zeros (e.g if $a is "1.20", it can be encoded as 1.20, not just "1.20" or 1.2).

Right now, it is not possible to encode a decimal number with trailing zeros. Example: one wants a number to have exactly 2 decimal digits, padded with zeros if necessary. So one can write

    my $formatted_number = sprintf("%.2f", $number);

However, $formatted_number was used as a string, so it will be encoded as a string, thus quoted. $formatted_number can be numified, by writing, for example,

    $formatted_number = 0 + $formatted_number;

but in this case, if there are trailing zeros, they are lost.

With the proposed solution, one does not numify $formatted_number, but rather calls

    JSON::PP::number_if_looks_like_one($formatted_number);

The return value will be encoded as number and will retain the trailing zeros.