### PR TITLE
add option disallow_dupkeys

### DIFF
--- a/t/026_duplicate.t
+++ b/t/026_duplicate.t
@@ -1,0 +1,26 @@
+# copied over from JSON::XS and modified to use JSON::PP
+
+use Test::More;
+use strict;
+
+BEGIN { plan tests => 4 };
+
+BEGIN { $ENV{PERL_JSON_BACKEND} = 0; }
+
+BEGIN {
+    use lib qw(t);
+    use _unicode_handling;
+}
+
+use utf8;
+use JSON::PP;
+
+
+my $json = JSON::PP->new;
+
+is (encode_json $json->decode ('{"a":"b","a":"c"}'), '{"a":"c"}'); # t/test_parsing/y_object_duplicated_key.json
+is (encode_json $json->decode ('{"a":"b","a":"b"}'), '{"a":"b"}'); # t/test_parsing/y_object_duplicated_key_and_value.json
+
+$json->disallow_dupkeys;
+ok (!eval { $json->decode ('{"a":"b","a":"c"}') }); # t/test_parsing/y_object_duplicated_key.json
+ok (!eval { $json->decode ('{"a":"b","a":"b"}') }); # t/test_parsing/y_object_duplicated_key_and_value.json


### PR DESCRIPTION
The JSON spec allows duplicate name in objects, however Perl hashes do not, and parsing JSON in Perl silently ignores duplicate names, using the last value found.

The option disallow_dupkeys, when enabled, will instead throw an error when duplicate names are found. It is useful in some cases to know when the JSON being parsed has values which will be ignored.

A similar pull request has been done for Cpanel-JSON-XS: https://github.com/rurban/Cpanel-JSON-XS/pull/75