### PR TITLE
Add support for type spec via second param in encode_json()

### DIFF
--- a/lib/JSON/PP/Spec.pm
+++ b/lib/JSON/PP/Spec.pm
@@ -1,0 +1,43 @@
+package JSON::PP::Spec;
+
+use strict;
+use warnings;
+
+use base 'Exporter';
+our @EXPORT = our @EXPORT_OK = qw(anyof arrayof hashof);
+
+sub anyof {
+    my $has_hash;
+    my $has_array;
+    my $has_scalar;
+    foreach ( @_ ) {
+        my $type = ref($_);
+        if ( $type ne '' ) {
+            if ( $type eq 'HASH' or $type eq 'JSON::PP::Spec::HashOf' ) {
+                die 'Only one hash type can be specified in anyof' if $has_hash;
+                $has_hash = 1;
+            } elsif ( $type eq 'ARRAY' or $type eq 'JSON::PP::Spec::ArrayOf' ) {
+                die 'Only one array type can be specified in anyof' if $has_array;
+                $has_array = 1;
+            } else {
+                die 'Only scalar, array or hash can be specified in anyof';
+            }
+        } elsif ( $_ ne 'NULL' ) {
+            die 'Only one scalar type can be specified in anyof' if $has_scalar;
+            $has_scalar = 1;
+        }
+    }
+    return bless \@_, 'JSON::PP::Spec::AnyOf';
+}
+
+sub arrayof {
+    die 'Exactly one type must be specified in arrayof' if scalar @_ != 1;
+    return bless \$_[0], 'JSON::PP::Spec::ArrayOf';
+}
+
+sub hashof {
+    die 'Exactly one type must be specified in hashof' if scalar @_ != 1;
+    return bless \$_[0], 'JSON::PP::Spec::HashOf';
+}
+
+1;

--- a/t/019_incr.t
+++ b/t/019_incr.t
@@ -57,10 +57,10 @@ splitter +JSON::PP->new->allow_nonref, ' "5" ';
       my $j4 = $coder->incr_parse; ok ($coder->incr_text !~ s/^\s*,//, "cskip4");
       my $j5 = $coder->incr_parse; ok ($coder->incr_text !~ s/^\s*,//, "cskip5");
 
-      ok ('[5]' eq encode_json $j1, "cjson1");
-      ok ('{"":1}' eq encode_json $j2, "cjson2");
-      ok ('[1,2,3]' eq encode_json $j3, "cjson3");
-      ok ('{"3":null}' eq encode_json $j4, "cjson4");
+      ok ('[5]' eq encode_json($j1), "cjson1");
+      ok ('{"":1}' eq encode_json($j2), "cjson2");
+      ok ('[1,2,3]' eq encode_json($j3), "cjson3");
+      ok ('{"3":null}' eq encode_json($j4), "cjson4");
       ok (!defined $j5, "cjson5");
    }
 }

--- a/t/type-spec.t
+++ b/t/type-spec.t
@@ -1,0 +1,66 @@
+use strict;
+use Test::More;
+BEGIN { plan tests => 74 };
+BEGIN { $ENV{PERL_JSON_BACKEND} = 0 };
+use JSON::PP;
+use JSON::PP::Spec;
+
+foreach my $false (JSON::PP::false, undef, 0, !!0, !1, "0", "", \0) {
+    is(encode_json([$false], ['BOOL']), '[false]');
+}
+
+foreach my $true (JSON::PP::true, 1, !!1, !0, 2, 3, 100, -1, -100, "1", "2", "100", "-1", "-1", "true", "string", \1) {
+    is(encode_json([$true], ['BOOL']), '[true]');
+}
+
+foreach my $zero (0, 0.0, "0") {
+    is(encode_json([$zero], ['NULL']), '[null]');
+    is(encode_json([$zero], ['BOOL']), '[false]');
+    is(encode_json([$zero], ['INT']), '[0]');
+    is(encode_json([$zero], ['FLOAT']), '[0.0]');
+    is(encode_json([$zero], ['STRING']), '["0"]');
+}
+
+foreach my $ten (10, 10.0, "10") {
+    is(encode_json([$ten], ['NULL']), '[null]');
+    is(encode_json([$ten], ['BOOL']), '[true]');
+    is(encode_json([$ten], ['INT']), '[10]');
+    is(encode_json([$ten], ['FLOAT']), '[10.0]');
+    is(encode_json([$ten], ['STRING']), '["10"]');
+}
+
+ok('[null]' eq encode_json [JSON::PP::false], ['NULL']);
+ok('[false]' eq encode_json [JSON::PP::false], ['BOOL']);
+ok('[0]' eq encode_json [JSON::PP::false], ['INT']);
+ok('[0.0]' eq encode_json [JSON::PP::false], ['FLOAT']);
+ok('["false"]' eq encode_json [JSON::PP::false], ['STRING']);
+ok('[false]' eq encode_json [JSON::PP::false], ['SCALAR']);
+ok('[false]' eq encode_json [JSON::PP::false], arrayof('SCALAR'));
+ok('[false]' eq encode_json [JSON::PP::false], [anyof('SCALAR')]);
+
+ok('[null]' eq encode_json [JSON::PP::true], ['NULL']);
+ok('[true]' eq encode_json [JSON::PP::true], ['BOOL']);
+ok('[1]' eq encode_json [JSON::PP::true], ['INT']);
+ok('[1.0]' eq encode_json [JSON::PP::true], ['FLOAT']);
+ok('["true"]' eq encode_json [JSON::PP::true], ['STRING']);
+ok('[true]' eq encode_json [JSON::PP::true], ['SCALAR']);
+ok('[true]' eq encode_json [JSON::PP::true], arrayof('SCALAR'));
+ok('[true]' eq encode_json [JSON::PP::true], [anyof('SCALAR')]);
+
+is(
+    encode_json(
+        [ { key1 => 'value1', key2 => 12 }, 1, [ 100, '101', JSON::PP::true ], undef ],
+        arrayof(anyof('STRING', 'NULL', [ 'INT', 'INT', 'BOOL' ], hashof('STRING'))),
+    ),
+    '[{"key2":"12","key1":"value1"},"1",[100,101,true],null]',
+);
+
+is(
+    encode_json(
+        [ { key1 => '11', key2 => [ 12, 13 ] } ],
+        [ { key1 => 'INT', key2 => [ 'STRING', 'INT' ] } ],
+    ),
+    '[{"key2":["12",13],"key1":11}]',
+);
+
+is(encode_json([["a"]], arrayof(anyof(arrayof(anyof({}, "STRING")), {}, "INT"))), '[["a"]]');


### PR DESCRIPTION
It is backward compatible. Second parameter is optional and when not present or is undef then old behavior is used. With second parameter can be specified json type, so encode_json() can distinguish between strings, integers and booleans.

This is POC. I'm creating this pull request, so we can discuss about it. Not for immediate merge request.

It is proposal how to fix a problem that perl by design does not distinguish between string and integer stored in scalar, but encode_json() needs to do it.