### PR TITLE
Fix is_bool

### DIFF
--- a/lib/JSON/PP.pm
+++ b/lib/JSON/PP.pm
@@ -1405,7 +1405,7 @@ BEGIN {
 $JSON::PP::true  = do { bless \(my $dummy = 1), "JSON::PP::Boolean" };
 $JSON::PP::false = do { bless \(my $dummy = 0), "JSON::PP::Boolean" };
 
-sub is_bool { defined $_[0] and UNIVERSAL::isa($_[0], "JSON::PP::Boolean"); }
+sub is_bool { ref $_[0] and $_[0]->isa("JSON::PP::Boolean"); }
 
 sub true  { $JSON::PP::true  }
 sub false { $JSON::PP::false }

--- a/t/003_types.t
+++ b/t/003_types.t
@@ -2,7 +2,7 @@
 use strict;
 use Test::More;
 
-BEGIN { plan tests => 76 };
+BEGIN { plan tests => 77 };
 
 BEGIN { $ENV{PERL_JSON_BACKEND} = 0; }
 
@@ -21,6 +21,7 @@ ok ($false == !$true);
 ok (JSON::PP::is_bool $false);
 ok (++$false == 1);
 ok (!JSON::PP::is_bool $false);
+ok (!JSON::PP::is_bool "JSON::PP::Boolean");
 
 ok (JSON::PP->new->allow_nonref (1)->decode ('5') == 5);
 ok (JSON::PP->new->allow_nonref (1)->decode ('-5') == -5);


### PR DESCRIPTION
is_bool uses UNIVERSAL::isa, which isn't now recommended.
This notably causes a problem with the string "JSON::PP::Boolean",
which it incorrectly identifies as a boolean value.

Fix by using ->isa("JSON::PP::Boolean") as recommended by perldoc.