### PR TITLE
always encode utf8 flagged scalars as strings

### DIFF
--- a/lib/JSON/PP.pm
+++ b/lib/JSON/PP.pm
@@ -416,6 +416,8 @@ sub allow_bigint {
             return;
         } else {
             no warnings 'numeric';
+            # if the utf8 flag is on, it almost certainly started as a string
+            return if utf8::is_utf8($value);
             # detect numbers
             # string & "" -> ""
             # number & "" -> 0 (with warning)


### PR DESCRIPTION
It is very unlikely that a utf8 flagged scalar started as a number.
That would only generally happen if the flag was explicitly enabled.
And that basically counts as modifying the scalar to turn it into a
string.

This also avoids using the bitwise op on a string with wide characters
in it, which is likely to start warning in future perl versions.