### PR TITLE
[Work in Progress] Boolean support with Data::Bool

### DIFF
--- a/lib/JSON/PP.pm
+++ b/lib/JSON/PP.pm
@@ -9,7 +9,7 @@ use Exporter ();
 BEGIN { @JSON::PP::ISA = ('Exporter') }
 
 use overload ();
-use Data::Bool qw(true false is_bool BOOL_PACKAGE);
+use Data::Bool qw(true false is_bool);
 
 use Carp ();
 #use Devel::Peek;
@@ -326,7 +326,7 @@ sub allow_bigint {
         elsif ($type) { # blessed object?
             if (blessed($obj)) {
 
-                return $self->value_to_json($obj) if ( $obj->isa(BOOL_PACKAGE) );
+                return $self->value_to_json($obj) if ( $obj->isa(Data::Bool::BOOL_PACKAGE) );
 
                 if ( $convert_blessed and $obj->can('TO_JSON') ) {
                     my $result = $obj->TO_JSON();
@@ -442,7 +442,7 @@ sub allow_bigint {
             }
             return $self->string_to_json($value);
         }
-        elsif( blessed($value) and  $value->isa(BOOL_PACKAGE) ){
+        elsif( blessed($value) and  $value->isa(Data::Bool::BOOL_PACKAGE) ){
             return $$value == 1 ? 'true' : 'false';
         }
         else {

--- a/lib/JSON/PP.pm
+++ b/lib/JSON/PP.pm
@@ -9,7 +9,7 @@ use Exporter ();
 BEGIN { @JSON::PP::ISA = ('Exporter') }
 
 use overload ();
-use JSON::PP::Boolean;
+use Types::Bool qw(true false is_bool);
 
 use Carp ();
 #use Devel::Peek;
@@ -326,7 +326,7 @@ sub allow_bigint {
         elsif ($type) { # blessed object?
             if (blessed($obj)) {
 
-                return $self->value_to_json($obj) if ( $obj->isa('JSON::PP::Boolean') );
+                return $self->value_to_json($obj) if ( $obj->isa('Types::Bool') );
 
                 if ( $convert_blessed and $obj->can('TO_JSON') ) {
                     my $result = $obj->TO_JSON();
@@ -442,7 +442,7 @@ sub allow_bigint {
             }
             return $self->string_to_json($value);
         }
-        elsif( blessed($value) and  $value->isa('JSON::PP::Boolean') ){
+        elsif( blessed($value) and  $value->isa('Types::Bool') ){
             return $$value == 1 ? 'true' : 'false';
         }
         else {
@@ -1404,14 +1404,8 @@ BEGIN {
 
 # shamelessly copied and modified from JSON::XS code.
 
-$JSON::PP::true  = JSON::PP::Boolean::true;
-$JSON::PP::false = JSON::PP::Boolean::false;
-
-BEGIN {
-    *is_bool = \&JSON::PP::Boolean::is_bool;
-    *true    = \&JSON::PP::Boolean::true;
-    *false   = \&JSON::PP::Boolean::false;
-}
+$JSON::PP::true  = true;
+$JSON::PP::false = false;
 
 sub null  { undef; }
 

--- a/lib/JSON/PP.pm
+++ b/lib/JSON/PP.pm
@@ -9,7 +9,7 @@ use Exporter ();
 BEGIN { @JSON::PP::ISA = ('Exporter') }
 
 use overload ();
-use Types::Bool qw(true false is_bool);
+use Types::Bool qw(true false is_bool BOOL_PACKAGE);
 
 use Carp ();
 #use Devel::Peek;
@@ -326,7 +326,7 @@ sub allow_bigint {
         elsif ($type) { # blessed object?
             if (blessed($obj)) {
 
-                return $self->value_to_json($obj) if ( $obj->isa('Types::Bool') );
+                return $self->value_to_json($obj) if ( $obj->isa(BOOL_PACKAGE) );
 
                 if ( $convert_blessed and $obj->can('TO_JSON') ) {
                     my $result = $obj->TO_JSON();
@@ -442,7 +442,7 @@ sub allow_bigint {
             }
             return $self->string_to_json($value);
         }
-        elsif( blessed($value) and  $value->isa('Types::Bool') ){
+        elsif( blessed($value) and  $value->isa(BOOL_PACKAGE) ){
             return $$value == 1 ? 'true' : 'false';
         }
         else {

--- a/lib/JSON/PP.pm
+++ b/lib/JSON/PP.pm
@@ -1404,13 +1404,15 @@ BEGIN {
 
 # shamelessly copied and modified from JSON::XS code.
 
-$JSON::PP::true  = do { bless \(my $dummy = 1), "JSON::PP::Boolean" };
-$JSON::PP::false = do { bless \(my $dummy = 0), "JSON::PP::Boolean" };
+$JSON::PP::true  = JSON::PP::Boolean::true;
+$JSON::PP::false = JSON::PP::Boolean::false;
 
-sub is_bool { blessed $_[0] and $_[0]->isa("JSON::PP::Boolean"); }
+BEGIN {
+    *is_bool = \&JSON::PP::Boolean::is_bool;
+    *true    = \&JSON::PP::Boolean::true;
+    *false   = \&JSON::PP::Boolean::false;
+}
 
-sub true  { $JSON::PP::true  }
-sub false { $JSON::PP::false }
 sub null  { undef; }
 
 ###############################

--- a/lib/JSON/PP.pm
+++ b/lib/JSON/PP.pm
@@ -9,7 +9,7 @@ use Exporter ();
 BEGIN { @JSON::PP::ISA = ('Exporter') }
 
 use overload ();
-use Types::Bool qw(true false is_bool BOOL_PACKAGE);
+use Data::Bool qw(true false is_bool BOOL_PACKAGE);
 
 use Carp ();
 #use Devel::Peek;

--- a/lib/JSON/PP/Boolean.pm
+++ b/lib/JSON/PP/Boolean.pm
@@ -1,8 +1,6 @@
 
 use Types::Bool ();
 
-package JSON::PP::Boolean;
-
 1;
 
 __END__

--- a/lib/JSON/PP/Boolean.pm
+++ b/lib/JSON/PP/Boolean.pm
@@ -1,6 +1,11 @@
 
 use Types::Bool ();
 
+package JSON::PP::Boolean;
+
+$JSON::PP::Boolean::VERSION = '2.97001'
+  unless $JSON::PP::Boolean::VERSION;
+
 1;
 
 __END__

--- a/lib/JSON/PP/Boolean.pm
+++ b/lib/JSON/PP/Boolean.pm
@@ -1,5 +1,5 @@
 
-use Types::Bool ();
+use Data::Bool ();
 
 package JSON::PP::Boolean;
 

--- a/lib/JSON/PP/Boolean.pm
+++ b/lib/JSON/PP/Boolean.pm
@@ -1,14 +1,7 @@
 
-BEGIN {
-    require Types::Bool;
-    *JSON::PP::Boolean:: = *Types::Bool::;
-}
+use Types::Bool ();
 
 package JSON::PP::Boolean;
-
-use strict;
-
-$JSON::PP::Boolean::VERSION = '2.97001';
 
 1;
 

--- a/lib/JSON/PP/Boolean.pm
+++ b/lib/JSON/PP/Boolean.pm
@@ -1,12 +1,12 @@
+
+BEGIN {
+    require Types::Bool;
+    *JSON::PP::Boolean:: = *Types::Bool::;
+}
+
 package JSON::PP::Boolean;
 
 use strict;
-use overload (
-    "0+"     => sub { ${$_[0]} },
-    "++"     => sub { $_[0] = ${$_[0]} + 1 },
-    "--"     => sub { $_[0] = ${$_[0]} - 1 },
-    fallback => 1,
-);
 
 $JSON::PP::Boolean::VERSION = '2.97001';
 


### PR DESCRIPTION
This is meant for discussion on moving the boolean support of JSON::PP to other module, which can be used as the common interface for other Perl modules which need booleans as objects and which are interested in interoperability.

I have been working on Types::Bool  at https://github.com/aferreira/cpan-Types-Bool and the latest release on CPAN is: https://metacpan.org/release/FERREIRA/Types-Bool-2.98010 