### PR TITLE
WIP Move boolean code to bool.pm

### DIFF
--- a/lib/JSON/PP.pm
+++ b/lib/JSON/PP.pm
@@ -9,7 +9,7 @@ use Exporter ();
 BEGIN { @JSON::PP::ISA = ('Exporter') }
 
 use overload ();
-use JSON::PP::Boolean;
+use bool;
 
 use Carp ();
 #use Devel::Peek;
@@ -326,7 +326,7 @@ sub allow_bigint {
         elsif ($type) { # blessed object?
             if (blessed($obj)) {
 
-                return $self->value_to_json($obj) if ( $obj->isa('JSON::PP::Boolean') );
+                return $self->value_to_json($obj) if ( $obj->isa('bool') );
 
                 if ( $convert_blessed and $obj->can('TO_JSON') ) {
                     my $result = $obj->TO_JSON();
@@ -442,7 +442,7 @@ sub allow_bigint {
             }
             return $self->string_to_json($value);
         }
-        elsif( blessed($value) and  $value->isa('JSON::PP::Boolean') ){
+        elsif( blessed($value) and  $value->isa('bool') ){
             return $$value == 1 ? 'true' : 'false';
         }
         else {
@@ -1407,7 +1407,7 @@ BEGIN {
 $JSON::PP::true  = do { bless \(my $dummy = 1), "JSON::PP::Boolean" };
 $JSON::PP::false = do { bless \(my $dummy = 0), "JSON::PP::Boolean" };
 
-sub is_bool { blessed $_[0] and $_[0]->isa("JSON::PP::Boolean"); }
+sub is_bool { bool::is_bool(@_) }
 
 sub true  { $JSON::PP::true  }
 sub false { $JSON::PP::false }

--- a/lib/JSON/PP/Boolean.pm
+++ b/lib/JSON/PP/Boolean.pm
@@ -1,13 +1,5 @@
 package JSON::PP::Boolean;
 
-use strict;
-use overload (
-    "0+"     => sub { ${$_[0]} },
-    "++"     => sub { $_[0] = ${$_[0]} + 1 },
-    "--"     => sub { $_[0] = ${$_[0]} - 1 },
-    fallback => 1,
-);
-
 $JSON::PP::Boolean::VERSION = '2.97001';
 
 1;


### PR DESCRIPTION
bool.pm can be found on github currently: https://github.com/perlpunk/bool-p5

As discussed with @charsbar and @jberger in Oslo at the Toolchain Summit,
bool.pm will simply take over functionality of JSON::PP::Boolean for now.
I had proposed a different solution first, but @charsbar preferred this
one. I can make a PR/branch for my other solution for comparison, though.

With this solution, all modules using JSON::PP::Boolean will simply
continue working.

I added some convenience functions to bool.pm, `complement` to get the
negated value (I would prefer `not`, though), and `perl` to convert the object
to `1 / ''`.

The overload methods are public methods, so they are documented, and
people can inherit from or even overwrite them, if necessary.
I've seen someone on Stackoverflow doing this to get "true" and "false" as
boolean values, since they simply wanted to dump the data and were confused
about the objects they got instead of true or false:

```
$JSON::PP::true = "true";
$JSON::PP::false = "false";
my $data = decode_json($json);
```

This should be discouraged, as they are not documented and might change.
Overwriting methods is a bit cleaner, IMHO.

As discussed at the Summit with @xsawyerx, bool.pm might be an candidate for
perl core, but of course this should be proposed on the mailing list first,
and discussed with module authors who are using JSON::PP::Boolean.

When bool.pm is established, JSON/YAML module authors can update their
code to check for `isa('bool')` at some point.

Ideally, at some point in the future, bool.pm could return real `bool` objects
instead of `JSON::PP::Boolean`.

