### PR TITLE
Document the indent_length option that appeared in version 4.01

### DIFF
--- a/bin/json_pp
+++ b/bin/json_pp
@@ -174,7 +174,7 @@ options to JSON::PP
 Acceptable options are:
 
     ascii latin1 utf8 pretty indent space_before space_after relaxed canonical allow_nonref
-    allow_singlequote allow_barekey allow_bignum loose escape_slash
+    allow_singlequote allow_barekey allow_bignum loose escape_slash indent_length
 
 Multiple options must be separated by commas:
 


### PR DESCRIPTION
There are two lists of options, and the one in the documentation section wasn't updated.