### PR TITLE
support core boolean values

### DIFF
--- a/lib/JSON/PP.pm
+++ b/lib/JSON/PP.pm
@@ -1492,11 +1492,14 @@ BEGIN {
     }
 }
 
-
-# shamelessly copied and modified from JSON::XS code.
-
-$JSON::PP::true  = do { bless \(my $dummy = 1), "JSON::PP::Boolean" };
-$JSON::PP::false = do { bless \(my $dummy = 0), "JSON::PP::Boolean" };
+if (CORE_BOOL) {
+  $JSON::PP::true = !!1;
+  $JSON::PP::false = !!0;
+}
+else {
+  $JSON::PP::true  = do { bless \(my $dummy = 1), "JSON::PP::Boolean" };
+  $JSON::PP::false = do { bless \(my $dummy = 0), "JSON::PP::Boolean" };
+}
 
 sub is_bool {
   if (blessed $_[0]) {

--- a/t/118_boolean_values.t
+++ b/t/118_boolean_values.t
@@ -28,7 +28,8 @@ if (eval "require boolean; 1") {
     push @tests, [boolean::true(), boolean::false(), 'boolean', 'boolean', 1];
 }
 if (eval "require JSON::PP; 1") {
-    push @tests, [JSON::PP::true(), JSON::PP::false(), 'JSON::PP::Boolean', 'JSON::PP::Boolean'];
+    # values from JSON::PP may not be the boolean objects, so reconstruct them
+    push @tests, [bless(\(my $jpbt = 1), 'JSON::PP::Boolean'), bless(\(my $jpbf = 0), 'JSON::PP::Boolean'), 'JSON::PP::Boolean', 'JSON::PP::Boolean'];
 }
 if (eval "require Data::Bool; 1") {
     push @tests, [Data::Bool::true(), Data::Bool::false(), 'Data::Bool::Impl', 'Data::Bool::Impl'];

--- a/t/118_boolean_values.t
+++ b/t/118_boolean_values.t
@@ -38,7 +38,7 @@ if (eval "require Types::Serialiser; 1") {
     push @tests, [Types::Serialiser::true(), Types::Serialiser::false(), 'Types::Serialiser::BooleanBase', 'Types::Serialiser::BooleanBase'];
 }
 
-plan tests => 15 * @tests;
+plan tests => 17 * @tests;
 
 my $json = JSON::PP->new;
 for my $test (@tests) {
@@ -77,8 +77,20 @@ for my $test (@tests) {
     ok !$json->get_boolean_values, "reset boolean values";
 
     $should_true = $json->allow_nonref(1)->decode('true');
-    ok $should_true->isa('JSON::PP::Boolean'), "JSON true turns into a JSON::PP::Boolean object";
+    ok +JSON::PP::is_bool($should_true), "JSON true decoded into boolean";
+    if (JSON::PP::CORE_BOOL) {
+      ok !ref $should_true && $should_true eq 1, "JSON true decoded into normal perl boolean";
+    }
+    else {
+      ok $should_true->isa("JSON::PP::Boolean"), "JSON true decoded into a JSON::PP::Boolean object";
+    }
 
     $should_false = $json->allow_nonref(1)->decode('false');
-    ok $should_false->isa('JSON::PP::Boolean'), "JSON false turns into a JSON::PP::Boolean object";
+    ok +JSON::PP::is_bool($should_false), "JSON false decoded into boolean";
+    if (JSON::PP::CORE_BOOL) {
+      ok !ref $should_false && $should_false eq '', "JSON false decoded into normal perl boolean";
+    }
+    else {
+      ok $should_false->isa("JSON::PP::Boolean"), "JSON false decoded into a JSON::PP::Boolean object";
+    }
 }


### PR DESCRIPTION
There is currently a draft PR to add trackable boolean values to perl: Perl/perl5#19040

This PR adds support for those boolean values to JSON::PP.

The first commit recognizes the core boolean values and encodes them as JSON true/false values. If the core change goes ahead, this would definitely be wanted.

The second commit decodes JSON booleans into core perl boolean values. This would be nice, and is what we would want if perl had always had core boolean values. But it presents compatibility problems. Possibly we'll want a different solution, like a `->core_bools` method as an easy alternative to `->boolean_values(!!0, !!1)`.