### PR TITLE
add core_bools option to support decoding as core booleans

### DIFF
--- a/lib/JSON/PP.pm
+++ b/lib/JSON/PP.pm
@@ -209,6 +209,30 @@ sub boolean_values {
     return $self;
 }
 
+sub core_bools {
+    my $self = shift;
+    my $core_bools = defined $_[0] ? $_[0] : 1;
+    if ($core_bools) {
+        $self->{true} = !!1;
+        $self->{false} = !!0;
+    }
+    else {
+        $self->{true} = $JSON::PP::true;
+        $self->{false} = $JSON::PP::false;
+    }
+    return $self;
+}
+
+sub get_core_bools {
+    return !!0
+        if !CORE_BOOL;
+
+    my $self = shift;
+    my ($true, $false) = @{$self}{qw(true false)};
+    BEGIN { CORE_BOOL and warnings->unimport(qw(experimental::builtin)) }
+    return builtin::is_bool($true) && builtin::is_bool($false) && $true && !$false;
+}
+
 sub get_boolean_values {
     my $self = shift;
     if (exists $self->{true} and exists $self->{false}) {

--- a/lib/JSON/PP.pm
+++ b/lib/JSON/PP.pm
@@ -46,6 +46,7 @@ use constant P_ALLOW_TAGS           => 19;
 
 use constant OLD_PERL => $] < 5.008 ? 1 : 0;
 use constant USE_B => $ENV{PERL_JSON_PP_USE_B} || 0;
+use constant CORE_BOOL => defined &builtin::is_bool;
 
 BEGIN {
     if (USE_B) {
@@ -476,7 +477,11 @@ sub allow_bigint {
         my $type = ref($value);
 
         if (!$type) {
-            if (_looks_like_number($value)) {
+            BEGIN { CORE_BOOL and warnings->unimport('experimental::builtin') }
+            if (CORE_BOOL && builtin::is_bool($value)) {
+                return $value ? 'true' : 'false';
+            }
+            elsif (_looks_like_number($value)) {
                 return $value;
             }
             return $self->string_to_json($value);
@@ -1493,7 +1498,20 @@ BEGIN {
 $JSON::PP::true  = do { bless \(my $dummy = 1), "JSON::PP::Boolean" };
 $JSON::PP::false = do { bless \(my $dummy = 0), "JSON::PP::Boolean" };
 
-sub is_bool { blessed $_[0] and ( $_[0]->isa("JSON::PP::Boolean") or $_[0]->isa("Types::Serialiser::BooleanBase") or $_[0]->isa("JSON::XS::Boolean") ); }
+sub is_bool {
+  if (blessed $_[0]) {
+    return (
+      $_[0]->isa("JSON::PP::Boolean")
+      or $_[0]->isa("Types::Serialiser::BooleanBase")
+      or $_[0]->isa("JSON::XS::Boolean")
+    );
+  }
+  elsif (CORE_BOOL) {
+    BEGIN { CORE_BOOL and warnings->unimport('experimental::builtin') }
+    return builtin::is_bool($_[0]);
+  }
+  return !!0;
+}
 
 sub true  { $JSON::PP::true  }
 sub false { $JSON::PP::false }

--- a/t/core_bools.t
+++ b/t/core_bools.t
@@ -1,0 +1,61 @@
+use strict;
+use warnings;
+use Test::More tests => 18;
+use JSON::PP;
+
+my $json = JSON::PP->new;
+
+is $json->get_core_bools, !!0, 'core_bools initially false';
+
+my $ret = $json->core_bools;
+is $ret => $json, "returns the same object";
+
+SKIP: {
+    skip "core_bools option doesn't register as true without core boolean support", 1
+        unless JSON::PP::CORE_BOOL;
+    is $json->get_core_bools, !!1, 'core_bools option enabled';
+}
+
+my ($new_false, $new_true) = $json->get_boolean_values;
+
+ok defined $new_true, "core true value is defined";
+ok defined $new_false, "core false value is defined";
+
+ok !ref $new_true, "core true value is not blessed";
+ok !ref $new_false, "core falase value is not blessed";
+
+{
+    my @warnings;
+    local $SIG{__WARN__} = sub {
+        push @warnings, @_;
+        warn @_;
+    };
+
+    cmp_ok $new_true, 'eq', '1', 'core true value is "1"';
+    cmp_ok $new_true, '==', 1, 'core true value is 1';
+
+    cmp_ok $new_false, 'eq', '', 'core false value is ""';
+    cmp_ok $new_false, '==', 0, 'core false value is 0';
+
+    is scalar @warnings, 0, 'no warnings';
+}
+
+SKIP: {
+    skip "core boolean support needed to detect core booleans", 2
+        unless JSON::PP::CORE_BOOL;
+    ok JSON::PP::is_bool($new_true), 'core true is a boolean';
+    ok JSON::PP::is_bool($new_false), 'core false is a boolean';
+}
+
+my $should_true = $json->allow_nonref(1)->decode('true');
+my $should_false = $json->allow_nonref(1)->decode('false');
+
+ok !ref $should_true && $should_true, "JSON true turns into an unblessed true value";
+ok !ref $should_false && !$should_false, "JSON false turns into an unblessed false value";
+
+SKIP: {
+    skip "core boolean support needed to detect core booleans", 2
+        unless JSON::PP::CORE_BOOL;
+    ok JSON::PP::is_bool($should_true), 'decoded true is a boolean';
+    ok JSON::PP::is_bool($should_false), 'decoded false is a boolean';
+}


### PR DESCRIPTION
With this option set, booleans will be decoded into standard perl
boolean values. On older perls, these will not be recognised by the
is_bool function and will not encode as boolean values. On perl
5.35.7 and newer, the values will be able to round trip properly.

Many things assume that the default boolean values are JSON::PP::Boolean
objects, so for now this is not the default.