### PR TITLE
Generalize to work on EBCDIC systems

### DIFF
--- a/lib/JSON/PP.pm
+++ b/lib/JSON/PP.pm
@@ -47,6 +47,17 @@ use constant P_ALLOW_TAGS           => 19;
 use constant OLD_PERL => $] < 5.008 ? 1 : 0;
 use constant USE_B => $ENV{PERL_JSON_PP_USE_B} || 0;
 
+my $invalid_char_re;
+
+BEGIN {
+    $invalid_char_re = "[";
+    for my $i (0 .. 0x01F, 0x22, 0x5c) { # '/' is ok
+        $invalid_char_re .= quotemeta chr utf8::unicode_to_native($i);
+    }
+
+    $invalid_char_re = qr/$invalid_char_re]/;
+}
+
 BEGIN {
     if (USE_B) {
         require B;
@@ -527,9 +538,11 @@ sub allow_bigint {
     sub string_to_json {
         my ($self, $arg) = @_;
 
-        $arg =~ s/([\x22\x5c\n\r\t\f\b])/$esc{$1}/g;
+        $arg =~ s/(["\\\n\r\t\f\b])/$esc{$1}/g;
         $arg =~ s/\//\\\//g if ($escape_slash);
-        $arg =~ s/([\x00-\x08\x0b\x0e-\x1f])/'\\u00' . unpack('H2', $1)/eg;
+
+        # On ASCII platforms, matches [\x00-\x08\x0b\x0e-\x1f]
+        $arg =~ s/([^\n\t\c?[:^cntrl:][:^ascii:]])/'\\u00' . unpack('H2', $1)/eg;
 
         if ($ascii) {
             $arg = JSON_PP_encode_ascii($arg);
@@ -604,7 +617,7 @@ sub allow_bigint {
 sub _encode_ascii {
     join('',
         map {
-            $_ <= 127 ?
+            chr($_) =~ /[[:ascii:]]/ ?
                 chr($_) :
             $_ <= 65535 ?
                 sprintf('\u%04x', $_) : sprintf('\u%x\u%x', _encode_surrogates($_));
@@ -658,11 +671,11 @@ BEGIN {
 { # PARSE 
 
     my %escapes = ( #  by Jeremy Muhlich <jmuhlich [at] bitflood.org>
-        b    => "\x8",
-        t    => "\x9",
-        n    => "\xA",
-        f    => "\xC",
-        r    => "\xD",
+        b    => "\b",
+        t    => "\t",
+        n    => "\n",
+        f    => "\f",
+        r    => "\r",
         '\\' => '\\',
         '"'  => '"',
         '/'  => '/',
@@ -853,7 +866,8 @@ BEGIN {
                                 decode_error("surrogate pair expected");
                             }
 
-                            if ( ( my $hex = hex( $u ) ) > 127 ) {
+                            my $hex = hex( $u );
+                            if ( chr $u =~ /[[:^ascii:]]/ ) {
                                 $is_utf8 = 1;
                                 $s .= JSON_PP_decode_unicode($u) || next;
                             }
@@ -873,7 +887,7 @@ BEGIN {
                 }
                 else{
 
-                    if ( ord $ch  > 127 ) {
+                    if ( $ch =~ /[[:^ascii:]]/ ) {
                         unless( $ch = is_valid_utf8($ch) ) {
                             $at -= 1;
                             decode_error("malformed UTF-8 character in JSON string");
@@ -886,10 +900,12 @@ BEGIN {
                     }
 
                     if (!$loose) {
-                        if ($ch =~ /[\x00-\x1f\x22\x5c]/)  { # '/' ok
+                        if ($ch =~ $invalid_char_re)  { # '/' ok
                             if (!$relaxed or $ch ne "\t") {
                                 $at--;
-                                decode_error('invalid character encountered while parsing JSON string');
+                                decode_error(sprintf "invalid character 0x%X"
+                                   . " encountered while parsing JSON string",
+                                   ord $ch);
                             }
                         }
                     }
@@ -1102,7 +1118,7 @@ BEGIN {
 
     sub bareKey { # doesn't strictly follow Standard ECMA-262 3rd Edition
         my $key;
-        while($ch =~ /[^\x00-\x23\x25-\x2F\x3A-\x40\x5B-\x5E\x60\x7B-\x7F]/){
+        while($ch =~ /[\$\w[:^ascii:]]/){
             $key .= $ch;
             next_chr();
         }
@@ -1235,31 +1251,52 @@ BEGIN {
         return $is_dec ? $v/1.0 : 0+$v;
     }
 
+    # Compute how many bytes are in the longest legal official Unicode
+    # character
+    my $max_unicode_length = chr 0x10FFFF;
+    utf8::encode($max_unicode_length);
+    $max_unicode_length = length $max_unicode_length;
 
     sub is_valid_utf8 {
 
-        $utf8_len = $_[0] =~ /[\x00-\x7F]/  ? 1
-                  : $_[0] =~ /[\xC2-\xDF]/  ? 2
-                  : $_[0] =~ /[\xE0-\xEF]/  ? 3
-                  : $_[0] =~ /[\xF0-\xF4]/  ? 4
-                  : 0
-                  ;
+        # Returns undef (setting $utf8_len to 0) unless the next bytes in $text
+        # comprise a well-formed UTF-8 encoded character, in which case,
+        # return those bytes, setting $utf8_len to their count.
 
-        return unless $utf8_len;
+        my $start_point = substr($text, $at - 1);
 
-        my $is_valid_utf8 = substr($text, $at - 1, $utf8_len);
+        # Look no further than the maximum number of bytes in a single
+        # character
+        my $limit = $max_unicode_length;
+        $limit = length($start_point) if $limit > length($start_point);
 
-        return ( $is_valid_utf8 =~ /^(?:
-             [\x00-\x7F]
-            |[\xC2-\xDF][\x80-\xBF]
-            |[\xE0][\xA0-\xBF][\x80-\xBF]
-            |[\xE1-\xEC][\x80-\xBF][\x80-\xBF]
-            |[\xED][\x80-\x9F][\x80-\xBF]
-            |[\xEE-\xEF][\x80-\xBF][\x80-\xBF]
-            |[\xF0][\x90-\xBF][\x80-\xBF][\x80-\xBF]
-            |[\xF1-\xF3][\x80-\xBF][\x80-\xBF][\x80-\xBF]
-            |[\xF4][\x80-\x8F][\x80-\xBF][\x80-\xBF]
-        )$/x )  ? $is_valid_utf8 : '';
+        # Find the number of bytes comprising the first character in $text
+        # (without having to know the details of its internal representation).
+        # This loop will iterate just once on well-formed input.
+        while ($limit > 0) {    # Until we succeed or exhaust the input
+            my $copy = substr($start_point, 0, $limit);
+
+            # decode() will return true if all bytes are valid; false
+            # if any aren't.
+            if (utf8::decode($copy)) {
+
+                # Is valid: get the first character, convert back to bytes,
+                # and return those bytes.
+                $copy = substr($copy, 0, 1);
+                utf8::encode($copy);
+                $utf8_len = length $copy;
+                return substr($start_point, 0, $utf8_len);
+            }
+
+            # If it didn't work, it could be that there is a full legal character
+            # followed by a partial or malformed one.  Narrow the window and
+            # try again.
+            $limit--;
+        }
+
+        # Failed to find a legal UTF-8 character.
+        $utf8_len = 0;
+        return;
     }
 
 
@@ -1278,14 +1315,14 @@ BEGIN {
         }
 
         for my $c ( unpack( $type, $str ) ) { # emulate pv_uni_display() ?
-            $mess .=  $c == 0x07 ? '\a'
-                    : $c == 0x09 ? '\t'
-                    : $c == 0x0a ? '\n'
-                    : $c == 0x0d ? '\r'
-                    : $c == 0x0c ? '\f'
-                    : $c <  0x20 ? sprintf('\x{%x}', $c)
-                    : $c == 0x5c ? '\\\\'
-                    : $c <  0x80 ? chr($c)
+            my $chr_c = $c;
+            $mess .=  $chr_c eq '\\' ? '\\\\'
+                    : $chr_c =~ /[[:print:]]/ ? $chr_c
+                    : $chr_c eq '\a' ? '\a'
+                    : $chr_c eq '\t' ? '\t'
+                    : $chr_c eq '\n' ? '\n'
+                    : $chr_c eq '\r' ? '\r'
+                    : $chr_c eq '\f' ? '\f'
                     : sprintf('\x{%x}', $c)
                     ;
             if ( length $mess >= 20 ) {
@@ -1605,7 +1642,7 @@ INCR_PARSE:
             while ( $len > $p ) {
                 $s = substr( $text, $p, 1 );
                 last INCR_PARSE unless defined $s;
-                if ( ord($s) > 0x20 ) {
+                if ( ord($s) > ord " " ) {
                     if ( $s eq '#' ) {
                         $self->{incr_mode} = INCR_M_C0;
                         redo INCR_PARSE;
@@ -1679,7 +1716,7 @@ INCR_PARSE:
                 if ( $s eq "\x00" ) {
                     $p--;
                     last INCR_PARSE;
-                } elsif ( $s eq "\x09" or $s eq "\x0a" or $s eq "\x0d" or $s eq "\x20" ) {
+                } elsif ( $s =~ /^[\t\n\r ]$/) {
                     if ( !$self->{incr_nest} ) {
                         $p--; # do not eat the whitespace, let the next round do it
                         last INCR_PARSE;

--- a/t/001_utf8.t
+++ b/t/001_utf8.t
@@ -10,17 +10,23 @@ BEGIN { $ENV{PERL_JSON_BACKEND} = 0; }
 use utf8;
 use JSON::PP;
 
-
-is (JSON::PP->new->allow_nonref (1)->utf8 (1)->encode ("ü"), "\"\xc3\xbc\"");
-is (JSON::PP->new->allow_nonref (1)->encode ("ü"), "\"ü\"");
+my $pilcrow_utf8 = (ord "^" == 0x5E) ? "\xc2\xb6"  # 8859-1
+                 : (ord "^" == 0x5F) ? "\x80\x65"  # CP 1024
+                 :                     "\x78\x64"; # assume CP 037
+is (JSON::PP->new->allow_nonref (1)->utf8 (1)->encode ("¶"), "\"$pilcrow_utf8\"");
+is (JSON::PP->new->allow_nonref (1)->encode ("¶"), "\"¶\"");
 is (JSON::PP->new->allow_nonref (1)->ascii (1)->utf8 (1)->encode (chr 0x8000), '"\u8000"');
 is (JSON::PP->new->allow_nonref (1)->ascii (1)->utf8 (1)->pretty (1)->encode (chr 0x10402), "\"\\ud801\\udc02\"\n");
 
-eval { JSON::PP->new->allow_nonref (1)->utf8 (1)->decode ('"ü"') };
+eval { JSON::PP->new->allow_nonref (1)->utf8 (1)->decode ('"¶"') };
 ok $@ =~ /malformed UTF-8/;
 
-is (JSON::PP->new->allow_nonref (1)->decode ('"ü"'), "ü");
-is (JSON::PP->new->allow_nonref (1)->decode ('"\u00fc"'), "ü");
+is (JSON::PP->new->allow_nonref (1)->decode ('"¶"'), "¶");
+is (JSON::PP->new->allow_nonref (1)->decode ('"\u00b6"'), "¶");
 is (JSON::PP->new->allow_nonref (1)->decode ('"\ud801\udc02' . "\x{10204}\""), "\x{10402}\x{10204}");
-is (JSON::PP->new->allow_nonref (1)->decode ('"\"\n\\\\\r\t\f\b"'), "\"\012\\\015\011\014\010");
+
+my $controls = (ord "^" == 0x5E) ? "\012\\\015\011\014\010"
+             : (ord "^" == 0x5F) ? "\025\\\015\005\014\026"  # CP 1024
+             :                     "\045\\\015\005\014\026"; # assume CP 037
+is (JSON::PP->new->allow_nonref (1)->decode ('"\"\n\\\\\r\t\f\b"'), "\"$controls");
 

--- a/t/001_utf8.t
+++ b/t/001_utf8.t
@@ -11,16 +11,16 @@ use utf8;
 use JSON::PP;
 
 
-ok (JSON::PP->new->allow_nonref (1)->utf8 (1)->encode ("ü") eq "\"\xc3\xbc\"");
-ok (JSON::PP->new->allow_nonref (1)->encode ("ü") eq "\"ü\"");
-ok (JSON::PP->new->allow_nonref (1)->ascii (1)->utf8 (1)->encode (chr 0x8000) eq '"\u8000"');
-ok (JSON::PP->new->allow_nonref (1)->ascii (1)->utf8 (1)->pretty (1)->encode (chr 0x10402) eq "\"\\ud801\\udc02\"\n");
+is (JSON::PP->new->allow_nonref (1)->utf8 (1)->encode ("ü"), "\"\xc3\xbc\"");
+is (JSON::PP->new->allow_nonref (1)->encode ("ü"), "\"ü\"");
+is (JSON::PP->new->allow_nonref (1)->ascii (1)->utf8 (1)->encode (chr 0x8000), '"\u8000"');
+is (JSON::PP->new->allow_nonref (1)->ascii (1)->utf8 (1)->pretty (1)->encode (chr 0x10402), "\"\\ud801\\udc02\"\n");
 
 eval { JSON::PP->new->allow_nonref (1)->utf8 (1)->decode ('"ü"') };
 ok $@ =~ /malformed UTF-8/;
 
-ok (JSON::PP->new->allow_nonref (1)->decode ('"ü"') eq "ü");
-ok (JSON::PP->new->allow_nonref (1)->decode ('"\u00fc"') eq "ü");
-ok (JSON::PP->new->allow_nonref (1)->decode ('"\ud801\udc02' . "\x{10204}\"") eq "\x{10402}\x{10204}");
-ok (JSON::PP->new->allow_nonref (1)->decode ('"\"\n\\\\\r\t\f\b"') eq "\"\012\\\015\011\014\010");
+is (JSON::PP->new->allow_nonref (1)->decode ('"ü"'), "ü");
+is (JSON::PP->new->allow_nonref (1)->decode ('"\u00fc"'), "ü");
+is (JSON::PP->new->allow_nonref (1)->decode ('"\ud801\udc02' . "\x{10204}\""), "\x{10402}\x{10204}");
+is (JSON::PP->new->allow_nonref (1)->decode ('"\"\n\\\\\r\t\f\b"'), "\"\012\\\015\011\014\010");
 

--- a/t/008_pc_base.t
+++ b/t/008_pc_base.t
@@ -77,7 +77,7 @@ $obj = $pc->decode($js);
 is($obj->[0],"\x01");
 
 $obj = ["\e"];
-is($js = $pc->encode($obj),'["\\u001b"]');
+is($js = $pc->encode($obj), (ord("A") == 65) ? '["\\u001b"]' : '["\\u0027"]');
 $obj = $pc->decode($js);
 is($obj->[0],"\e");
 

--- a/t/014_latin1.t
+++ b/t/014_latin1.t
@@ -11,9 +11,9 @@ use JSON::PP;
 
 my $pp = JSON::PP->new->latin1->allow_nonref;
 
-ok ($pp->encode ("\x{12}\x{89}       ") eq "\"\\u0012\x{89}       \"");
-ok ($pp->encode ("\x{12}\x{89}\x{abc}") eq "\"\\u0012\x{89}\\u0abc\"");
+ok ($pp->encode ("\x{12}\x{b6}       ") eq "\"\\u0012\x{b6}       \"");
+ok ($pp->encode ("\x{12}\x{b6}\x{abc}") eq "\"\\u0012\x{b6}\\u0abc\"");
 
-ok ($pp->decode ("\"\\u0012\x{89}\""       ) eq "\x{12}\x{89}");
-ok ($pp->decode ("\"\\u0012\x{89}\\u0abc\"") eq "\x{12}\x{89}\x{abc}");
+ok ($pp->decode ("\"\\u0012\x{b6}\""       ) eq "\x{12}\x{b6}");
+ok ($pp->decode ("\"\\u0012\x{b6}\\u0abc\"") eq "\x{12}\x{b6}\x{abc}");
 

--- a/t/108_decode.t
+++ b/t/108_decode.t
@@ -9,6 +9,8 @@ BEGIN { plan tests => 6 };
 
 BEGIN { $ENV{PERL_JSON_BACKEND} = 0; }
 
+my $isASCII = ord "A" == 65;
+
 use JSON::PP;
 
 no utf8;
@@ -22,16 +24,20 @@ is($json->decode(q|"\u00c3\u00bc"|), "\xc3\xbc"); # utf8
 
 my $str = 'あ'; # Japanese 'a' in utf8
 
-is($json->decode(q|"\u00e3\u0081\u0082"|), $str);
+is($json->decode(($isASCII) ? q|"\u00e3\u0081\u0082"|
+                            : q|"\u00ce\u0043\u0043"|),
+                  $str);
 
 utf8::decode($str); # usually UTF-8 flagged on, but no-op for 5.005.
 
 is($json->decode(q|"\u3042"|), $str);
 
 
-my $utf8 = $json->decode(q|"\ud808\udf45"|); # chr 12345
+# chr 0x12400, which was chosen because it has the same representation in
+# both EBCDIC 1047 and 037
+my $utf8 = $json->decode(q|"\ud809\udc00"|);
 
 utf8::encode($utf8); # UTF-8 flagged off
 
-is($utf8, "\xf0\x92\x8d\x85");
+is($utf8, ($isASCII) ? "\xf0\x92\x90\x80" : "\xDE\x4A\x41\x41");
 

--- a/t/109_encode.t
+++ b/t/109_encode.t
@@ -9,20 +9,46 @@ BEGIN { plan tests => 7 };
 
 BEGIN { $ENV{PERL_JSON_BACKEND} = 0; }
 
+my $isASCII = ord "A" == 65;
+
 use JSON::PP;
 
 no utf8;
 
 my $json = JSON::PP->new->allow_nonref;
 
-is($json->encode("ü"),                   q|"ü"|); # as is
+# U+00B6 chosen because it works on both ASCII and EBCDIC
+is($json->encode("¶"),                   q|"¶"|); # as is
 
 $json->ascii;
 
-is($json->encode("\xfc"),           q|"\u00fc"|); # latin1
-is($json->encode("\xc3\xbc"), q|"\u00c3\u00bc"|); # utf8
-is($json->encode("ü"),        q|"\u00c3\u00bc"|); # utf8
-is($json->encode('あ'), q|"\u00e3\u0081\u0082"|);
+if ($] < 5.008) {
+    is($json->encode("\xb6"),           q|"\u00b6"|); # latin1
+    is($json->encode("\xc2\xb6"), q|"\u00c2\u00b6"|); # utf8
+    is($json->encode("¶"),        q|"\u00c2\u00b6"|); # utf8
+    is($json->encode('あ'), q|"\u00e3\u0081\u0082"|);
+}
+else  {
+    is($json->encode("\xb6"),           q|"\u00b6"|); # latin1
+
+    if (ord "A" == 65)  {
+        is($json->encode("\xc2\xb6"), q|"\u00c2\u00b6"|); # utf8
+        is($json->encode("¶"),        q|"\u00c2\u00b6"|); # utf8
+        is($json->encode('あ'), q|"\u00e3\u0081\u0082"|);
+    }
+    else {
+        if (ord '^' == 95) {    # EBCDIC 1047
+            is($json->encode("\x80\x65"), q|"\u0080\u0065"|); # utf8
+            is($json->encode("¶"),        q|"\u0080\u0065"|); # utf8
+        }
+        else {  # Assume EBCDIC 037
+            is($json->encode("\x78\x64"), q|"\u0078\u0064"|); # utf8
+            is($json->encode("¶"),        q|"\u0078\u0064"|); # utf8
+        }
+
+        is($json->encode('あ'), (q|"\u00ce\u0043\u0043"|));
+    }
+}
 
 if ($] >= 5.006) {
     is($json->encode(chr hex 3042 ),  q|"\u3042"|);

--- a/t/112_upgrade.t
+++ b/t/112_upgrade.t
@@ -9,17 +9,17 @@ BEGIN { $ENV{PERL_JSON_BACKEND} = 0; }
 use JSON::PP;
 
 my $json = JSON::PP->new->allow_nonref->utf8;
-my $str  = '\\u00c8';
+my $str  = '\\u00b6';
 
-my $value = $json->decode( '"\\u00c8"' );
+my $value = $json->decode( '"\\u00b6"' );
 
 #use Devel::Peek;
 #Dump( $value );
 
-is( $value, chr 0xc8 );
+is( $value, chr 0xb6 );
 
 ok( utf8::is_utf8( $value ) );
 
-eval { $json->decode( '"' . chr(0xc8) . '"' ) };
+eval { $json->decode( '"' . chr(0xb6) . '"' ) };
 ok( $@ =~ /malformed UTF-8 character in JSON string/ );
 


### PR DESCRIPTION
Perl once again works on EBCDIC platforms, but JSON::PP doesn't.  These patches remedy this, and hence also fix some other modules shipped with the Perl core that rely on J:P