### PR TITLE
`incr_parse()` Hangs on Certain Inputs

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -22,6 +22,7 @@ WriteMakefile(
     'VERSION_FROM'  => 'lib/JSON/PP.pm', # finds $VERSION
     'PREREQ_PM'     => {
               'Test::More'  => 0,
+              'Test::Fork'  => 0,
               %prereq,
     },
     'EXE_FILES' => [ 'bin/json_pp' ],

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -22,7 +22,6 @@ WriteMakefile(
     'VERSION_FROM'  => 'lib/JSON/PP.pm', # finds $VERSION
     'PREREQ_PM'     => {
               'Test::More'  => 0,
-              'Test::Fork'  => 0,
               %prereq,
     },
     'EXE_FILES' => [ 'bin/json_pp' ],

--- a/lib/JSON/PP.pm
+++ b/lib/JSON/PP.pm
@@ -1697,6 +1697,7 @@ INCR_PARSE:
             }
             next;
         } elsif ( $mode == INCR_M_TFN ) {
+            last INCR_PARSE if $p >= $len && $self->{incr_nest};
             while ( $len > $p ) {
                 $s = substr( $text, $p++, 1 );
                 next if defined $s and $s =~ /[rueals]/;
@@ -1708,6 +1709,7 @@ INCR_PARSE:
             last INCR_PARSE unless $self->{incr_nest};
             redo INCR_PARSE;
         } elsif ( $mode == INCR_M_NUM ) {
+            last INCR_PARSE if $p >= $len && $self->{incr_nest};
             while ( $len > $p ) {
                 $s = substr( $text, $p++, 1 );
                 next if defined $s and $s =~ /[0-9eE.+\-]/;

--- a/t/120_incr_parse_truncated.t
+++ b/t/120_incr_parse_truncated.t
@@ -1,29 +1,15 @@
 use strict;
 no warnings;
 use Test::More;
-BEGIN { plan tests => 19 * (6 + 2) + 1 * (12 + 2) };
+BEGIN { plan tests => 19 * (6) + 1 * (12) };
 
 BEGIN { $ENV{PERL_JSON_BACKEND} = 0; }
 
 use JSON::PP;
 
-################################################################
-###  Warning: Some inputs may get stuck in an infinite loop  ###
-###      so we're going to run each test under `Test::Fork`  ###
-################################################################
-
-use Test::Fork;
 sub run_test {
     my ($num_tests, $input, $sub) = @_;
-    my $pid = fork_ok($num_tests => sub {
-        setpgrp 0, 0;
-        $sub->($input);
-    });
-
-    local $SIG{ALRM} = sub { warn "\e[31mnot ok - '$input' hung; killing $pid...\e[m\n"; kill -9, $pid };
-    alarm 10;
-    waitpid $pid, 0;
-    alarm 0;
+    $sub->($input);
 }
 
 #################################################################

--- a/t/120_incr_parse_truncated.t
+++ b/t/120_incr_parse_truncated.t
@@ -1,7 +1,7 @@
 use strict;
 no warnings;
 use Test::More;
-BEGIN { plan tests => 19 * (6) + 1 * (12) };
+BEGIN { plan tests => 19 * 3 + 1 * 6 };
 
 BEGIN { $ENV{PERL_JSON_BACKEND} = 0; }
 
@@ -14,219 +14,216 @@ sub run_test {
 
 #################################################################
 
-# Try 'JSON::XS' and 'JSON::PP'...
-for my $JSON_LIB (qw< JSON::XS JSON::PP >) {
-    unless ( eval "use ${JSON_LIB}(); 1" ) {
-        diag "$JSON_LIB not found; skipping...";
-        next;
-    }
-
-    run_test(3, '{"one": 1}', sub {
-        my $input = shift;
-        my $coder = $JSON_LIB->new;
-        my $res = eval { $coder->incr_parse($input) };
-        my $e = $@; # test more clobbers $@, we need it twice
-        ok ($res, "$JSON_LIB: curly braces okay -- '$input'");
-        ok (!$e, "$JSON_LIB: no error -- '$input'");
-        unlike ($e, qr/, or \} expected while parsing object\/hash/, "$JSON_LIB: No '} expected' json string error");
-    });
-
-    run_test(3, '{"one": 1]', sub {
-        my $input = shift;
-        my $coder = $JSON_LIB->new;
-        my $res = eval { $coder->incr_parse($input) };
-        my $e = $@; # test more clobbers $@, we need it twice
-        ok (!$res, "$JSON_LIB: unbalanced curly braces -- '$input'");
-        ok ($e, "$JSON_LIB: got error -- '$input'");
-        like ($e, qr/, or \} expected while parsing object\/hash/, "$JSON_LIB: '} expected' json string error");
-    });
-
-    run_test(3, '"', sub {
-        my $input = shift;
-        my $coder = $JSON_LIB->new;
-        my $res = eval { $coder->incr_parse($input) };
-        my $e = $@; # test more clobbers $@, we need it twice
-        ok (!$res, "$JSON_LIB: truncated input='$input'");
-        ok (!$e, "$JSON_LIB: no error for input='$input'");
-        unlike ($e, qr/, or \} expected while parsing object\/hash/, "$JSON_LIB: No '} expected' json string error for input='$input'");
-    });
-
-    run_test(3, '{', sub {
-        my $input = shift;
-        my $coder = $JSON_LIB->new;
-        my $res = eval { $coder->incr_parse($input) };
-        my $e = $@; # test more clobbers $@, we need it twice
-        ok (!$res, "$JSON_LIB: truncated input='$input'");
-        ok (!$e, "$JSON_LIB: no error for input='$input'");
-        unlike ($e, qr/, or \} expected while parsing object\/hash/, "$JSON_LIB: No '} expected' json string error for input='$input'");
-    });
-
-    run_test(3, '[', sub {
-        my $input = shift;
-        my $coder = $JSON_LIB->new;
-        my $res = eval { $coder->incr_parse($input) };
-        my $e = $@; # test more clobbers $@, we need it twice
-        ok (!$res, "$JSON_LIB: truncated input='$input'");
-        ok (!$e, "$JSON_LIB: no error for input='$input'");
-        unlike ($e, qr/, or \} expected while parsing object\/hash/, "$JSON_LIB: No '} expected' json string error for input='$input'");
-    });
-
-    run_test(3, '}', sub {
-        my $input = shift;
-        my $coder = $JSON_LIB->new;
-        my $res = eval { $coder->incr_parse($input) };
-        my $e = $@; # test more clobbers $@, we need it twice
-        ok (!$res, "$JSON_LIB: truncated input='$input'");
-        ok ($e, "$JSON_LIB: no error for input='$input'");
-        like ($e, qr/malformed JSON string/, "$JSON_LIB: 'malformed JSON string' json string error for input='$input'");
-    });
-
-    run_test(3, ']', sub {
-        my $input = shift;
-        my $coder = $JSON_LIB->new;
-        my $res = eval { $coder->incr_parse($input) };
-        my $e = $@; # test more clobbers $@, we need it twice
-        ok (!$res, "$JSON_LIB: truncated input='$input'");
-        ok ($e, "$JSON_LIB: no error for input='$input'");
-        like ($e, qr/malformed JSON string/, "$JSON_LIB: 'malformed JSON string' json string error for input='$input'");
-    });
-
-    run_test(3, '1', sub {
-        my $input = shift;
-        my $coder = $JSON_LIB->new;
-        my $res = eval { $coder->incr_parse($input) };
-        my $e = $@; # test more clobbers $@, we need it twice
-        ok ($res, "$JSON_LIB: truncated input='$input'");
-        ok (!$e, "$JSON_LIB: no error for input='$input'");
-        unlike ($e, qr/malformed JSON string/, "$JSON_LIB: 'malformed JSON string' json string error for input='$input'");
-    });
-
-    run_test(3, '1', sub {
-        my $input = shift;
-        my $coder = $JSON_LIB->new->allow_nonref(0);
-        my $res = eval { $coder->incr_parse($input) };
-        my $e = $@; # test more clobbers $@, we need it twice
-        ok (!$res, "$JSON_LIB: truncated input='$input'");
-        ok ($e, "$JSON_LIB: no error for input='$input'");
-        like ($e, qr/JSON text must be an object or array/, "$JSON_LIB: 'JSON text must be an object or array' json string error for input='$input'");
-    });
-
-    run_test(3, '"1', sub {
-        my $input = shift;
-        my $coder = $JSON_LIB->new;
-        my $res = eval { $coder->incr_parse($input) };
-        my $e = $@; # test more clobbers $@, we need it twice
-        ok (!$res, "$JSON_LIB: truncated input='$input'");
-        ok (!$e, "$JSON_LIB: no error for input='$input'");
-        unlike ($e, qr/malformed JSON string/, "$JSON_LIB: 'malformed JSON string' json string error for input='$input'");
-    });
-
-    run_test(3, '\\', sub {
-        my $input = shift;
-        my $coder = $JSON_LIB->new;
-        my $res = eval { $coder->incr_parse($input) };
-        my $e = $@; # test more clobbers $@, we need it twice
-        ok (!$res, "$JSON_LIB: truncated input='$input'");
-        ok ($e, "$JSON_LIB: no error for input='$input'");
-        like ($e, qr/malformed JSON string/, "$JSON_LIB: 'malformed JSON string' json string error for input='$input'");
-    });
-
-    run_test(3, '{"one": "', sub {
-        my $input = shift;
-        my $coder = $JSON_LIB->new;
-        my $res = eval { $coder->incr_parse($input) };
-        my $e = $@; # test more clobbers $@, we need it twice
-        ok (!$res, "$JSON_LIB: truncated input='$input'");
-        ok (!$e, "$JSON_LIB: no error for input='$input'");
-        unlike ($e, qr/, or \} expected while parsing object\/hash/, "$JSON_LIB: No '} expected' json string error for input='$input'");
-    });
-
-    run_test(3, '{"one": {', sub {
-        my $input = shift;
-        my $coder = $JSON_LIB->new;
-        my $res = eval { $coder->incr_parse($input) };
-        my $e = $@; # test more clobbers $@, we need it twice
-        ok (!$res, "$JSON_LIB: truncated input='$input'");
-        ok (!$e, "$JSON_LIB: no error for input='$input'");
-        unlike ($e, qr/, or \} expected while parsing object\/hash/, "$JSON_LIB: No '} expected' json string error for input='$input'");
-    });
-
-    run_test(3, '{"one": [', sub {
-        my $input = shift;
-        my $coder = $JSON_LIB->new;
-        my $res = eval { $coder->incr_parse($input) };
-        my $e = $@; # test more clobbers $@, we need it twice
-        ok (!$res, "$JSON_LIB: truncated input='$input'");
-        ok (!$e, "$JSON_LIB: no error for input='$input'");
-        unlike ($e, qr/, or \} expected while parsing object\/hash/, "$JSON_LIB: No '} expected' json string error for input='$input'");
-    });
-
-    run_test(3, '{"one": t', sub {
-        my $input = shift;
-        my $coder = $JSON_LIB->new;
-        my $res = eval { $coder->incr_parse($input) };
-        my $e = $@; # test more clobbers $@, we need it twice
-        ok (!$res, "$JSON_LIB: truncated input='$input'");
-        ok (!$e, "$JSON_LIB: no error for input='$input'");
-        unlike ($e, qr/, or \} expected while parsing object\/hash/, "$JSON_LIB: No '} expected' json string error for input='$input'");
-    });
-
-    run_test(3, '{"one": \\', sub {
-        my $input = shift;
-        my $coder = $JSON_LIB->new;
-        my $res = eval { $coder->incr_parse($input) };
-        my $e = $@; # test more clobbers $@, we need it twice
-        ok (!$res, "$JSON_LIB: truncated input='$input'");
-        ok (!$e, "$JSON_LIB: no error for input='$input'");
-        unlike ($e, qr/, or \} expected while parsing object\/hash/, "$JSON_LIB: No '} expected' json string error for input='$input'");
-    });
-
-    run_test(3, '{"one": ', sub {
-        my $input = shift;
-        my $coder = $JSON_LIB->new;
-        my $res = eval { $coder->incr_parse($input) };
-        my $e = $@; # test more clobbers $@, we need it twice
-        ok (!$res, "$JSON_LIB: truncated input='$input'");
-        ok (!$e, "$JSON_LIB: no error for input='$input'");
-        unlike ($e, qr/, or \} expected while parsing object\/hash/, "$JSON_LIB: No '} expected' json string error for input='$input'");
-    });
-
-    run_test(3, '{"one": 1', sub {
-        my $input = shift;
-        my $coder = $JSON_LIB->new;
-        my $res = eval { $coder->incr_parse($input) };
-        my $e = $@; # test more clobbers $@, we need it twice
-        ok (!$res, "$JSON_LIB: truncated input='$input'");
-        ok (!$e, "$JSON_LIB: no error for input='$input'");
-        unlike ($e, qr/, or \} expected while parsing object\/hash/, "$JSON_LIB: No '} expected' json string error for input='$input'");
-    });
-
-    run_test(3, '{"one": {"two": 2', sub {
-        my $input = shift;
-        my $coder = $JSON_LIB->new;
-        my $res = eval { $coder->incr_parse($input) };
-        my $e = $@; # test more clobbers $@, we need it twice
-        ok (!$res, "$JSON_LIB: truncated '$input'");
-        ok (!$e, "$JSON_LIB: no error -- '$input'");
-        unlike ($e, qr/, or \} expected while parsing object\/hash/, "$JSON_LIB: No '} expected' json string error -- $input");
-    });
-
-    # Test Appending Closing '}' Curly Bracket
-    run_test(6, '{"one": 1', sub {
-        my $input = shift;
-        my $coder = $JSON_LIB->new;
-        {
-          my $res = eval { $coder->incr_parse($input) };
-          my $e = $@; # test more clobbers $@, we need it twice
-          ok (!$res, "$JSON_LIB: truncated input='$input'");
-          ok (!$e, "$JSON_LIB: no error for input='$input'");
-          unlike ($e, qr/, or \} expected while parsing object\/hash/, "$JSON_LIB: No '} expected' json string error for input='$input'");
-
-          $res = eval { $coder->incr_parse('}') };
-          $e = $@; # test more clobbers $@, we need it twice
-          ok ($res, "$JSON_LIB: truncated input='$input' . '}'");
-          ok (!$e, "$JSON_LIB: no error for input='$input' . '}'");
-          unlike ($e, qr/, or \} expected while parsing object\/hash/, "$JSON_LIB: No '} expected' json string error for input='$input' . '}'");
-        }
-    });
+unless ( eval "use JSON::PP(); 1" ) {
+    diag "JSON::PP not found; skipping...";
+    next;
 }
+
+run_test(3, '{"one": 1}', sub {
+    my $input = shift;
+    my $coder = JSON::PP->new;
+    my $res = eval { $coder->incr_parse($input) };
+    my $e = $@; # test more clobbers $@, we need it twice
+    ok ($res, "curly braces okay -- '$input'");
+    ok (!$e, "no error -- '$input'");
+    unlike ($e, qr/, or \} expected while parsing object\/hash/, "No '} expected' json string error");
+});
+
+run_test(3, '{"one": 1]', sub {
+    my $input = shift;
+    my $coder = JSON::PP->new;
+    my $res = eval { $coder->incr_parse($input) };
+    my $e = $@; # test more clobbers $@, we need it twice
+    ok (!$res, "unbalanced curly braces -- '$input'");
+    ok ($e, "got error -- '$input'");
+    like ($e, qr/, or \} expected while parsing object\/hash/, "'} expected' json string error");
+});
+
+run_test(3, '"', sub {
+    my $input = shift;
+    my $coder = JSON::PP->new;
+    my $res = eval { $coder->incr_parse($input) };
+    my $e = $@; # test more clobbers $@, we need it twice
+    ok (!$res, "truncated input='$input'");
+    ok (!$e, "no error for input='$input'");
+    unlike ($e, qr/, or \} expected while parsing object\/hash/, "No '} expected' json string error for input='$input'");
+});
+
+run_test(3, '{', sub {
+    my $input = shift;
+    my $coder = JSON::PP->new;
+    my $res = eval { $coder->incr_parse($input) };
+    my $e = $@; # test more clobbers $@, we need it twice
+    ok (!$res, "truncated input='$input'");
+    ok (!$e, "no error for input='$input'");
+    unlike ($e, qr/, or \} expected while parsing object\/hash/, "No '} expected' json string error for input='$input'");
+});
+
+run_test(3, '[', sub {
+    my $input = shift;
+    my $coder = JSON::PP->new;
+    my $res = eval { $coder->incr_parse($input) };
+    my $e = $@; # test more clobbers $@, we need it twice
+    ok (!$res, "truncated input='$input'");
+    ok (!$e, "no error for input='$input'");
+    unlike ($e, qr/, or \} expected while parsing object\/hash/, "No '} expected' json string error for input='$input'");
+});
+
+run_test(3, '}', sub {
+    my $input = shift;
+    my $coder = JSON::PP->new;
+    my $res = eval { $coder->incr_parse($input) };
+    my $e = $@; # test more clobbers $@, we need it twice
+    ok (!$res, "truncated input='$input'");
+    ok ($e, "no error for input='$input'");
+    like ($e, qr/malformed JSON string/, "'malformed JSON string' json string error for input='$input'");
+});
+
+run_test(3, ']', sub {
+    my $input = shift;
+    my $coder = JSON::PP->new;
+    my $res = eval { $coder->incr_parse($input) };
+    my $e = $@; # test more clobbers $@, we need it twice
+    ok (!$res, "truncated input='$input'");
+    ok ($e, "no error for input='$input'");
+    like ($e, qr/malformed JSON string/, "'malformed JSON string' json string error for input='$input'");
+});
+
+run_test(3, '1', sub {
+    my $input = shift;
+    my $coder = JSON::PP->new;
+    my $res = eval { $coder->incr_parse($input) };
+    my $e = $@; # test more clobbers $@, we need it twice
+    ok ($res, "truncated input='$input'");
+    ok (!$e, "no error for input='$input'");
+    unlike ($e, qr/malformed JSON string/, "'malformed JSON string' json string error for input='$input'");
+});
+
+run_test(3, '1', sub {
+    my $input = shift;
+    my $coder = JSON::PP->new->allow_nonref(0);
+    my $res = eval { $coder->incr_parse($input) };
+    my $e = $@; # test more clobbers $@, we need it twice
+    ok (!$res, "truncated input='$input'");
+    ok ($e, "no error for input='$input'");
+    like ($e, qr/JSON text must be an object or array/, "'JSON text must be an object or array' json string error for input='$input'");
+});
+
+run_test(3, '"1', sub {
+    my $input = shift;
+    my $coder = JSON::PP->new;
+    my $res = eval { $coder->incr_parse($input) };
+    my $e = $@; # test more clobbers $@, we need it twice
+    ok (!$res, "truncated input='$input'");
+    ok (!$e, "no error for input='$input'");
+    unlike ($e, qr/malformed JSON string/, "'malformed JSON string' json string error for input='$input'");
+});
+
+run_test(3, '\\', sub {
+    my $input = shift;
+    my $coder = JSON::PP->new;
+    my $res = eval { $coder->incr_parse($input) };
+    my $e = $@; # test more clobbers $@, we need it twice
+    ok (!$res, "truncated input='$input'");
+    ok ($e, "no error for input='$input'");
+    like ($e, qr/malformed JSON string/, "'malformed JSON string' json string error for input='$input'");
+});
+
+run_test(3, '{"one": "', sub {
+    my $input = shift;
+    my $coder = JSON::PP->new;
+    my $res = eval { $coder->incr_parse($input) };
+    my $e = $@; # test more clobbers $@, we need it twice
+    ok (!$res, "truncated input='$input'");
+    ok (!$e, "no error for input='$input'");
+    unlike ($e, qr/, or \} expected while parsing object\/hash/, "No '} expected' json string error for input='$input'");
+});
+
+run_test(3, '{"one": {', sub {
+    my $input = shift;
+    my $coder = JSON::PP->new;
+    my $res = eval { $coder->incr_parse($input) };
+    my $e = $@; # test more clobbers $@, we need it twice
+    ok (!$res, "truncated input='$input'");
+    ok (!$e, "no error for input='$input'");
+    unlike ($e, qr/, or \} expected while parsing object\/hash/, "No '} expected' json string error for input='$input'");
+});
+
+run_test(3, '{"one": [', sub {
+    my $input = shift;
+    my $coder = JSON::PP->new;
+    my $res = eval { $coder->incr_parse($input) };
+    my $e = $@; # test more clobbers $@, we need it twice
+    ok (!$res, "truncated input='$input'");
+    ok (!$e, "no error for input='$input'");
+    unlike ($e, qr/, or \} expected while parsing object\/hash/, "No '} expected' json string error for input='$input'");
+});
+
+run_test(3, '{"one": t', sub {
+    my $input = shift;
+    my $coder = JSON::PP->new;
+    my $res = eval { $coder->incr_parse($input) };
+    my $e = $@; # test more clobbers $@, we need it twice
+    ok (!$res, "truncated input='$input'");
+    ok (!$e, "no error for input='$input'");
+    unlike ($e, qr/, or \} expected while parsing object\/hash/, "No '} expected' json string error for input='$input'");
+});
+
+run_test(3, '{"one": \\', sub {
+    my $input = shift;
+    my $coder = JSON::PP->new;
+    my $res = eval { $coder->incr_parse($input) };
+    my $e = $@; # test more clobbers $@, we need it twice
+    ok (!$res, "truncated input='$input'");
+    ok (!$e, "no error for input='$input'");
+    unlike ($e, qr/, or \} expected while parsing object\/hash/, "No '} expected' json string error for input='$input'");
+});
+
+run_test(3, '{"one": ', sub {
+    my $input = shift;
+    my $coder = JSON::PP->new;
+    my $res = eval { $coder->incr_parse($input) };
+    my $e = $@; # test more clobbers $@, we need it twice
+    ok (!$res, "truncated input='$input'");
+    ok (!$e, "no error for input='$input'");
+    unlike ($e, qr/, or \} expected while parsing object\/hash/, "No '} expected' json string error for input='$input'");
+});
+
+run_test(3, '{"one": 1', sub {
+    my $input = shift;
+    my $coder = JSON::PP->new;
+    my $res = eval { $coder->incr_parse($input) };
+    my $e = $@; # test more clobbers $@, we need it twice
+    ok (!$res, "truncated input='$input'");
+    ok (!$e, "no error for input='$input'");
+    unlike ($e, qr/, or \} expected while parsing object\/hash/, "No '} expected' json string error for input='$input'");
+});
+
+run_test(3, '{"one": {"two": 2', sub {
+    my $input = shift;
+    my $coder = JSON::PP->new;
+    my $res = eval { $coder->incr_parse($input) };
+    my $e = $@; # test more clobbers $@, we need it twice
+    ok (!$res, "truncated '$input'");
+    ok (!$e, "no error -- '$input'");
+    unlike ($e, qr/, or \} expected while parsing object\/hash/, "No '} expected' json string error -- $input");
+});
+
+# Test Appending Closing '}' Curly Bracket
+run_test(6, '{"one": 1', sub {
+    my $input = shift;
+    my $coder = JSON::PP->new;
+    {
+      my $res = eval { $coder->incr_parse($input) };
+      my $e = $@; # test more clobbers $@, we need it twice
+      ok (!$res, "truncated input='$input'");
+      ok (!$e, "no error for input='$input'");
+      unlike ($e, qr/, or \} expected while parsing object\/hash/, "No '} expected' json string error for input='$input'");
+
+      $res = eval { $coder->incr_parse('}') };
+      $e = $@; # test more clobbers $@, we need it twice
+      ok ($res, "truncated input='$input' . '}'");
+      ok (!$e, "no error for input='$input' . '}'");
+      unlike ($e, qr/, or \} expected while parsing object\/hash/, "No '} expected' json string error for input='$input' . '}'");
+    }
+});

--- a/t/120_incr_parse_truncated.t
+++ b/t/120_incr_parse_truncated.t
@@ -1,0 +1,236 @@
+use strict;
+no warnings;
+use Test::More;
+BEGIN { plan tests => 19 * (6) + 1 * (12) };
+
+BEGIN { $ENV{PERL_JSON_BACKEND} = 0; }
+
+use JSON::PP;
+
+################################################################
+###  Warning: Some inputs may get stuck in an infinite loop  ###
+################################################################
+
+sub run_test {
+    my ($num_tests, $input, $sub) = @_;
+    $sub->($input);
+}
+
+#################################################################
+
+# Try 'JSON::XS' and 'JSON::PP'...
+for my $JSON_LIB (qw< JSON::XS JSON::PP >) {
+    unless ( eval "use ${JSON_LIB}(); 1" ) {
+        diag "$JSON_LIB not found; skipping...";
+        next;
+    }
+
+    run_test(3, '{"one": 1}', sub {
+        my $input = shift;
+        my $coder = $JSON_LIB->new;
+        my $res = eval { $coder->incr_parse($input) };
+        my $e = $@; # test more clobbers $@, we need it twice
+        ok ($res, "$JSON_LIB: curly braces okay -- '$input'");
+        ok (!$e, "$JSON_LIB: no error -- '$input'");
+        unlike ($e, qr/, or \} expected while parsing object\/hash/, "$JSON_LIB: No '} expected' json string error");
+    });
+
+    run_test(3, '{"one": 1]', sub {
+        my $input = shift;
+        my $coder = $JSON_LIB->new;
+        my $res = eval { $coder->incr_parse($input) };
+        my $e = $@; # test more clobbers $@, we need it twice
+        ok (!$res, "$JSON_LIB: unbalanced curly braces -- '$input'");
+        ok ($e, "$JSON_LIB: got error -- '$input'");
+        like ($e, qr/, or \} expected while parsing object\/hash/, "$JSON_LIB: '} expected' json string error");
+    });
+
+    run_test(3, '"', sub {
+        my $input = shift;
+        my $coder = $JSON_LIB->new;
+        my $res = eval { $coder->incr_parse($input) };
+        my $e = $@; # test more clobbers $@, we need it twice
+        ok (!$res, "$JSON_LIB: truncated input='$input'");
+        ok (!$e, "$JSON_LIB: no error for input='$input'");
+        unlike ($e, qr/, or \} expected while parsing object\/hash/, "$JSON_LIB: No '} expected' json string error for input='$input'");
+    });
+
+    run_test(3, '{', sub {
+        my $input = shift;
+        my $coder = $JSON_LIB->new;
+        my $res = eval { $coder->incr_parse($input) };
+        my $e = $@; # test more clobbers $@, we need it twice
+        ok (!$res, "$JSON_LIB: truncated input='$input'");
+        ok (!$e, "$JSON_LIB: no error for input='$input'");
+        unlike ($e, qr/, or \} expected while parsing object\/hash/, "$JSON_LIB: No '} expected' json string error for input='$input'");
+    });
+
+    run_test(3, '[', sub {
+        my $input = shift;
+        my $coder = $JSON_LIB->new;
+        my $res = eval { $coder->incr_parse($input) };
+        my $e = $@; # test more clobbers $@, we need it twice
+        ok (!$res, "$JSON_LIB: truncated input='$input'");
+        ok (!$e, "$JSON_LIB: no error for input='$input'");
+        unlike ($e, qr/, or \} expected while parsing object\/hash/, "$JSON_LIB: No '} expected' json string error for input='$input'");
+    });
+
+    run_test(3, '}', sub {
+        my $input = shift;
+        my $coder = $JSON_LIB->new;
+        my $res = eval { $coder->incr_parse($input) };
+        my $e = $@; # test more clobbers $@, we need it twice
+        ok (!$res, "$JSON_LIB: truncated input='$input'");
+        ok ($e, "$JSON_LIB: no error for input='$input'");
+        like ($e, qr/malformed JSON string/, "$JSON_LIB: 'malformed JSON string' json string error for input='$input'");
+    });
+
+    run_test(3, ']', sub {
+        my $input = shift;
+        my $coder = $JSON_LIB->new;
+        my $res = eval { $coder->incr_parse($input) };
+        my $e = $@; # test more clobbers $@, we need it twice
+        ok (!$res, "$JSON_LIB: truncated input='$input'");
+        ok ($e, "$JSON_LIB: no error for input='$input'");
+        like ($e, qr/malformed JSON string/, "$JSON_LIB: 'malformed JSON string' json string error for input='$input'");
+    });
+
+    run_test(3, '1', sub {
+        my $input = shift;
+        my $coder = $JSON_LIB->new;
+        my $res = eval { $coder->incr_parse($input) };
+        my $e = $@; # test more clobbers $@, we need it twice
+        ok ($res, "$JSON_LIB: truncated input='$input'");
+        ok (!$e, "$JSON_LIB: no error for input='$input'");
+        unlike ($e, qr/malformed JSON string/, "$JSON_LIB: 'malformed JSON string' json string error for input='$input'");
+    });
+
+    run_test(3, '1', sub {
+        my $input = shift;
+        my $coder = $JSON_LIB->new->allow_nonref(0);
+        my $res = eval { $coder->incr_parse($input) };
+        my $e = $@; # test more clobbers $@, we need it twice
+        ok (!$res, "$JSON_LIB: truncated input='$input'");
+        ok ($e, "$JSON_LIB: no error for input='$input'");
+        like ($e, qr/JSON text must be an object or array/, "$JSON_LIB: 'JSON text must be an object or array' json string error for input='$input'");
+    });
+
+    run_test(3, '"1', sub {
+        my $input = shift;
+        my $coder = $JSON_LIB->new;
+        my $res = eval { $coder->incr_parse($input) };
+        my $e = $@; # test more clobbers $@, we need it twice
+        ok (!$res, "$JSON_LIB: truncated input='$input'");
+        ok (!$e, "$JSON_LIB: no error for input='$input'");
+        unlike ($e, qr/malformed JSON string/, "$JSON_LIB: 'malformed JSON string' json string error for input='$input'");
+    });
+
+    run_test(3, '\\', sub {
+        my $input = shift;
+        my $coder = $JSON_LIB->new;
+        my $res = eval { $coder->incr_parse($input) };
+        my $e = $@; # test more clobbers $@, we need it twice
+        ok (!$res, "$JSON_LIB: truncated input='$input'");
+        ok ($e, "$JSON_LIB: no error for input='$input'");
+        like ($e, qr/malformed JSON string/, "$JSON_LIB: 'malformed JSON string' json string error for input='$input'");
+    });
+
+    run_test(3, '{"one": "', sub {
+        my $input = shift;
+        my $coder = $JSON_LIB->new;
+        my $res = eval { $coder->incr_parse($input) };
+        my $e = $@; # test more clobbers $@, we need it twice
+        ok (!$res, "$JSON_LIB: truncated input='$input'");
+        ok (!$e, "$JSON_LIB: no error for input='$input'");
+        unlike ($e, qr/, or \} expected while parsing object\/hash/, "$JSON_LIB: No '} expected' json string error for input='$input'");
+    });
+
+    run_test(3, '{"one": {', sub {
+        my $input = shift;
+        my $coder = $JSON_LIB->new;
+        my $res = eval { $coder->incr_parse($input) };
+        my $e = $@; # test more clobbers $@, we need it twice
+        ok (!$res, "$JSON_LIB: truncated input='$input'");
+        ok (!$e, "$JSON_LIB: no error for input='$input'");
+        unlike ($e, qr/, or \} expected while parsing object\/hash/, "$JSON_LIB: No '} expected' json string error for input='$input'");
+    });
+
+    run_test(3, '{"one": [', sub {
+        my $input = shift;
+        my $coder = $JSON_LIB->new;
+        my $res = eval { $coder->incr_parse($input) };
+        my $e = $@; # test more clobbers $@, we need it twice
+        ok (!$res, "$JSON_LIB: truncated input='$input'");
+        ok (!$e, "$JSON_LIB: no error for input='$input'");
+        unlike ($e, qr/, or \} expected while parsing object\/hash/, "$JSON_LIB: No '} expected' json string error for input='$input'");
+    });
+
+    run_test(3, '{"one": t', sub {
+        my $input = shift;
+        my $coder = $JSON_LIB->new;
+        my $res = eval { $coder->incr_parse($input) };
+        my $e = $@; # test more clobbers $@, we need it twice
+        ok (!$res, "$JSON_LIB: truncated input='$input'");
+        ok (!$e, "$JSON_LIB: no error for input='$input'");
+        unlike ($e, qr/, or \} expected while parsing object\/hash/, "$JSON_LIB: No '} expected' json string error for input='$input'");
+    });
+
+    run_test(3, '{"one": \\', sub {
+        my $input = shift;
+        my $coder = $JSON_LIB->new;
+        my $res = eval { $coder->incr_parse($input) };
+        my $e = $@; # test more clobbers $@, we need it twice
+        ok (!$res, "$JSON_LIB: truncated input='$input'");
+        ok (!$e, "$JSON_LIB: no error for input='$input'");
+        unlike ($e, qr/, or \} expected while parsing object\/hash/, "$JSON_LIB: No '} expected' json string error for input='$input'");
+    });
+
+    run_test(3, '{"one": ', sub {
+        my $input = shift;
+        my $coder = $JSON_LIB->new;
+        my $res = eval { $coder->incr_parse($input) };
+        my $e = $@; # test more clobbers $@, we need it twice
+        ok (!$res, "$JSON_LIB: truncated input='$input'");
+        ok (!$e, "$JSON_LIB: no error for input='$input'");
+        unlike ($e, qr/, or \} expected while parsing object\/hash/, "$JSON_LIB: No '} expected' json string error for input='$input'");
+    });
+
+    run_test(3, '{"one": 1', sub {
+        my $input = shift;
+        my $coder = $JSON_LIB->new;
+        my $res = eval { $coder->incr_parse($input) };
+        my $e = $@; # test more clobbers $@, we need it twice
+        ok (!$res, "$JSON_LIB: truncated input='$input'");
+        ok (!$e, "$JSON_LIB: no error for input='$input'");
+        unlike ($e, qr/, or \} expected while parsing object\/hash/, "$JSON_LIB: No '} expected' json string error for input='$input'");
+    });
+
+    run_test(3, '{"one": {"two": 2', sub {
+        my $input = shift;
+        my $coder = $JSON_LIB->new;
+        my $res = eval { $coder->incr_parse($input) };
+        my $e = $@; # test more clobbers $@, we need it twice
+        ok (!$res, "$JSON_LIB: truncated '$input'");
+        ok (!$e, "$JSON_LIB: no error -- '$input'");
+        unlike ($e, qr/, or \} expected while parsing object\/hash/, "$JSON_LIB: No '} expected' json string error -- $input");
+    });
+
+    # Test Appending Closing '}' Curly Bracket
+    run_test(6, '{"one": 1', sub {
+        my $input = shift;
+        my $coder = $JSON_LIB->new;
+        {
+          my $res = eval { $coder->incr_parse($input) };
+          my $e = $@; # test more clobbers $@, we need it twice
+          ok (!$res, "$JSON_LIB: truncated input='$input'");
+          ok (!$e, "$JSON_LIB: no error for input='$input'");
+          unlike ($e, qr/, or \} expected while parsing object\/hash/, "$JSON_LIB: No '} expected' json string error for input='$input'");
+
+          $res = eval { $coder->incr_parse('}') };
+          $e = $@; # test more clobbers $@, we need it twice
+          ok ($res, "$JSON_LIB: truncated input='$input' . '}'");
+          ok (!$e, "$JSON_LIB: no error for input='$input' . '}'");
+          unlike ($e, qr/, or \} expected while parsing object\/hash/, "$JSON_LIB: No '} expected' json string error for input='$input' . '}'");
+        }
+    });
+}

--- a/t/120_incr_parse_truncated.t
+++ b/t/120_incr_parse_truncated.t
@@ -1,7 +1,7 @@
 use strict;
 no warnings;
 use Test::More;
-BEGIN { plan tests => 19 * (6) + 1 * (12) };
+BEGIN { plan tests => 19 * (6 + 2) + 1 * (12 + 2) };
 
 BEGIN { $ENV{PERL_JSON_BACKEND} = 0; }
 
@@ -9,11 +9,21 @@ use JSON::PP;
 
 ################################################################
 ###  Warning: Some inputs may get stuck in an infinite loop  ###
+###      so we're going to run each test under `Test::Fork`  ###
 ################################################################
 
+use Test::Fork;
 sub run_test {
     my ($num_tests, $input, $sub) = @_;
-    $sub->($input);
+    my $pid = fork_ok($num_tests => sub {
+        setpgrp 0, 0;
+        $sub->($input);
+    });
+
+    local $SIG{ALRM} = sub { warn "\e[31mnot ok - '$input' hung; killing $pid...\e[m\n"; kill -9, $pid };
+    alarm 10;
+    waitpid $pid, 0;
+    alarm 0;
 }
 
 #################################################################


### PR DESCRIPTION
Notably, inputs that end in a number or `[tfn]`:
```
perl -MJSON::PP -e 'print JSON::PP->new->incr_parse(q|{"key": 1|)'
```

Whereas `JSON::XS` returns silently:
```
perl -MJSON::XS -e 'print JSON::XS->new->incr_parse(q|{"key": 1|)'
```

My fix is pretty trivial:
```
--- a/lib/JSON/PP.pm
+++ b/lib/JSON/PP.pm
@@ -1699,2 +1699,3 @@ INCR_PARSE:
         } elsif ( $mode == INCR_M_TFN ) {
+            last INCR_PARSE if $p >= $len && $self->{incr_nest};
             while ( $len > $p ) {
@@ -1710,2 +1711,3 @@ INCR_PARSE:
         } elsif ( $mode == INCR_M_NUM ) {
+            last INCR_PARSE if $p >= $len && $self->{incr_nest};
             while ( $len > $p ) {
```

But it's the tests that I spent the most time on (which is why I've left the PR unsquashed...)

Because the current behavior gets stuck in an infinite loop, I wanted to properly timeout, which meant reaching for [`Test::Fork`](https://metacpan.org/pod/Test::Fork):
```
use Test::Fork;
sub run_test {
    my ($num_tests, $input, $sub) = @_;
    my $pid = fork_ok($num_tests => sub {
        setpgrp 0, 0;
        $sub->($input);
    });

    local $SIG{ALRM} = sub { warn "\e[31mnot ok - '$input' hung; killing $pid...\e[m\n"; kill -9, $pid };
    alarm 10;
    waitpid $pid, 0;
    alarm 0;
}
```

If you have a better way, I'm all ears!  :-D