### PR TITLE
silence warnings about non-characters on older perls

### DIFF
--- a/lib/JSON/PP.pm
+++ b/lib/JSON/PP.pm
@@ -1273,7 +1273,10 @@ BEGIN {
 
     # Compute how many bytes are in the longest legal official Unicode
     # character
-    my $max_unicode_length = chr 0x10FFFF;
+    my $max_unicode_length = do {
+      BEGIN { $] >= 5.006 and require warnings and warnings->unimport('utf8') }
+      chr 0x10FFFF;
+    };
     utf8::encode($max_unicode_length);
     $max_unicode_length = length $max_unicode_length;
 


### PR DESCRIPTION
The last valid unicode codepoint is 0x10FFFF, but this is defined as a
non-character. perl versions <= 5.12 will warn when trying to use the
chr function on strings like this. JSON::PP doesn't enable warnings by
default, but they can still appear when using perl -w, which will often
happen when running tests. These unexpected warnings will break the
tests of ExtUtils::MakeMaker.

Since the module tries to be compatible with prehistoric perl versions,
check the perl version and then disable the utf8 warnings to avoid the
problem.