### PR TITLE
support encoding core booleans

### DIFF
--- a/t/003_types.t
+++ b/t/003_types.t
@@ -3,7 +3,7 @@
 use strict;
 use warnings;
 use Test::More;
-BEGIN { plan tests => 76 + 2 };
+BEGIN { plan tests => 78 + 2 };
 
 BEGIN { $ENV{PERL_JSON_BACKEND} = 0; }
 
@@ -46,6 +46,14 @@ ok ('[false]' eq encode_json [\0]);
 ok ('[null]'  eq encode_json [undef]);
 ok ('[true]'  eq encode_json [JSON::PP::true]);
 ok ('[false]' eq encode_json [JSON::PP::false]);
+
+SKIP: {
+  skip "core booleans not supported", 2
+    unless JSON::PP->can("CORE_BOOL") && JSON::PP::CORE_BOOL();
+
+  ok ('[true]'  eq encode_json [!!1]);
+  ok ('[false]' eq encode_json [!!0]);
+}
 
 for my $v (1, 2, 3, 5, -1, -2, -3, -4, 100, 1000, 10000, -999, -88, -7, 7, 88, 999, -1e5, 1e6, 1e7, 1e8) {
    ok ($v == ((decode_json "[$v]")->[0]));


### PR DESCRIPTION
Perl now has support for tracking boolean values. Use the new builtin
functions to perl booleans as json booleans.