### PR TITLE
add core_bools option to support decoding as core booleans

### DIFF
--- a/lib/JSON/PP.pm
+++ b/lib/JSON/PP.pm
@@ -251,6 +251,16 @@ sub get_core_bools {
     return !!$self->{core_bools};
 }
 
+sub unblessed_bool {
+    my $self = shift;
+    return $self->core_bools(@_);
+}
+
+sub get_unblessed_bool {
+    my $self = shift;
+    return $self->get_core_bools(@_);
+}
+
 sub get_boolean_values {
     my $self = shift;
     if (exists $self->{true} and exists $self->{false}) {
@@ -2342,6 +2352,9 @@ perl boolean values. Equivalent to calling:
 C<get_core_bools> will return true if this has been set. On perl 5.36, it will
 also return true if the boolean values have been set to perl's core booleans
 using the C<boolean_values> method.
+
+The methods C<unblessed_bool> and C<get_unblessed_bool> are provided as aliases
+for compatibility with L<Cpanel::JSON::XS>.
 
 =head2 filter_json_object
 

--- a/t/003_types.t
+++ b/t/003_types.t
@@ -3,7 +3,7 @@
 use strict;
 use warnings;
 use Test::More;
-BEGIN { plan tests => 76 + 2 };
+BEGIN { plan tests => 78 + 2 };
 
 BEGIN { $ENV{PERL_JSON_BACKEND} = 0; }
 
@@ -46,6 +46,14 @@ ok ('[false]' eq encode_json [\0]);
 ok ('[null]'  eq encode_json [undef]);
 ok ('[true]'  eq encode_json [JSON::PP::true]);
 ok ('[false]' eq encode_json [JSON::PP::false]);
+
+SKIP: {
+  skip "core booleans not supported", 2
+    unless JSON::PP->can("CORE_BOOL") && JSON::PP::CORE_BOOL();
+
+  ok ('[true]'  eq encode_json [!!1]);
+  ok ('[false]' eq encode_json [!!0]);
+}
 
 for my $v (1, 2, 3, 5, -1, -2, -3, -4, 100, 1000, 10000, -999, -88, -7, 7, 88, 999, -1e5, 1e6, 1e7, 1e8) {
    ok ($v == ((decode_json "[$v]")->[0]));

--- a/t/core_bools.t
+++ b/t/core_bools.t
@@ -1,0 +1,84 @@
+use strict;
+use warnings;
+use JSON::PP;
+use Test::More;
+BEGIN {
+  # this is only for JSON.pm
+  plan skip_all => 'no support for core boolean options'
+    unless JSON::PP->can('CORE_BOOL');
+}
+
+plan tests => 24;
+
+my $json = JSON::PP->new;
+
+is $json->get_core_bools, !!0, 'core_bools initially false';
+
+$json->boolean_values(!!0, !!1);
+SKIP: {
+    skip "core_bools option doesn't register as true for core bools without core boolean support", 1
+        unless JSON::PP::CORE_BOOL;
+
+    is $json->get_core_bools, !!1, 'core_bools true when setting bools to core bools';
+}
+
+$json->boolean_values(!!1, !!0);
+is $json->get_core_bools, !!0, 'core_bools false when setting bools to anything other than correct core bools';
+
+my $ret = $json->core_bools;
+is $ret, $json,
+  "returns the same object";
+
+my ($new_false, $new_true) = $json->get_boolean_values;
+
+# ensure this registers as true on older perls where the boolean values
+# themselves can't be tracked.
+is $json->get_core_bools, !!1, 'core_bools true when setting core_bools';
+
+ok defined $new_true, "core true value is defined";
+ok defined $new_false, "core false value is defined";
+
+ok !ref $new_true, "core true value is not blessed";
+ok !ref $new_false, "core falase value is not blessed";
+
+{
+    my @warnings;
+    local $SIG{__WARN__} = sub {
+        push @warnings, @_;
+        warn @_;
+    };
+
+    cmp_ok $new_true, 'eq', '1', 'core true value is "1"';
+    cmp_ok $new_true, '==', 1, 'core true value is 1';
+
+    cmp_ok $new_false, 'eq', '', 'core false value is ""';
+    cmp_ok $new_false, '==', 0, 'core false value is 0';
+
+    is scalar @warnings, 0, 'no warnings';
+}
+
+SKIP: {
+    skip "core boolean support needed to detect core booleans", 4
+        unless JSON::PP::CORE_BOOL;
+    ok JSON::PP::is_bool($new_true), 'core true is a boolean';
+    ok JSON::PP::is_bool($new_false), 'core false is a boolean';
+
+    ok builtin::is_bool($new_true), 'core true is a core boolean';
+    ok builtin::is_bool($new_false), 'core false is a core boolean';
+}
+
+my $should_true = $json->allow_nonref(1)->decode('true');
+my $should_false = $json->allow_nonref(1)->decode('false');
+
+ok !ref $should_true && $should_true, "JSON true turns into an unblessed true value";
+ok !ref $should_false && !$should_false, "JSON false turns into an unblessed false value";
+
+SKIP: {
+    skip "core boolean support needed to detect core booleans", 4
+        unless JSON::PP::CORE_BOOL;
+    ok JSON::PP::is_bool($should_true), 'decoded true is a boolean';
+    ok JSON::PP::is_bool($should_false), 'decoded false is a boolean';
+
+    ok JSON::PP::is_bool($should_true), 'decoded true is a core boolean';
+    ok JSON::PP::is_bool($should_false), 'decoded false is a core boolean';
+}


### PR DESCRIPTION
With this option set, booleans will be decoded into standard perl
boolean values. On older perls, these will not be recognised by the
is_bool function and will not encode as boolean values. On perl
5.35.7 and newer, the values will be able to round trip properly.

Many things assume that the default boolean values are JSON::PP::Boolean
objects, so for now this is not the default.