### PR TITLE
provide v2 metadata for META.json

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -26,9 +26,17 @@ WriteMakefile(
 
     ( $ExtUtils::MakeMaker::VERSION >= 6.46 ? (
         'META_MERGE' => {
+            'meta-spec' => { version => 2 },
+            dynamic_config => 0,
             resources => {
-                repository  =>  'https://github.com/makamaka/JSON-PP',
-                bugtracker  =>  'https://github.com/makamaka/JSON-PP/issues',
+                repository => {
+                    url => 'https://github.com/makamaka/JSON-PP.git',
+                    web => 'https://github.com/makamaka/JSON-PP',
+                    type => 'git',
+                },
+                bugtracker => {
+                    web => 'https://github.com/makamaka/JSON-PP/issues',
+                },
             },
         } ) : ()
     ),


### PR DESCRIPTION
Among other things, this also indicates that there are no dynamic prerequisites (META.json can be relied upon for the full list of dependencies). Therefore metacpan.org can also remove "and possibly others" from the list of dependencies.