### PR TITLE
Silence Getopt::Long warning

### DIFF
--- a/bin/json_pp
+++ b/bin/json_pp
@@ -2,7 +2,7 @@
 
 BEGIN { pop @INC if $INC[-1] eq '.' }
 use strict;
-use Getopt::Long;
+use Getopt::Long qw( :config no_ignore_case );
 use Encode ();
 
 use JSON::PP ();


### PR DESCRIPTION
Getopt::Long >= 2.55 produces the warning
'Duplicate specification "V" for option "v"
See issue #88 for prior report.