### PR TITLE
Add INSTALLDIRS key-value pair to Makefile.PL

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -22,6 +22,7 @@ WriteMakefile(
     'EXE_FILES' => [ 'bin/json_pp' ],
     'ABSTRACT_FROM' => 'lib/JSON/PP.pm', # retrieve abstract from module
     'AUTHOR'        => 'Makamaka Hannyaharamitu, E<lt>makamaka[at]cpan.orgE<gt>',
+    'INSTALLDIRS'   => ($] < 5.011 ? 'perl' : 'site'),
     ( $ExtUtils::MakeMaker::VERSION >= 6.3002 ? ('LICENSE' => 'perl', ) : () ),
 
     ( $ExtUtils::MakeMaker::VERSION >= 6.46 ? (


### PR DESCRIPTION
In the course of working on https://github.com/Perl/perl5/issues/12722, it became evident that the CPAN version of JSON-PP's `Makefile.PL` does not set an `INSTALLDIRS` key-value pair.  That raises the possibility that if someone were to install the library against a pre-5.12 perl, it would be installed in the wrong location.

This pull request adds an `INSTALLDIRS` key-value pair per the recommendation in
https://github.com/Perl/perl5/issues/12722#issuecomment-544040160. Please review.